### PR TITLE
ESLint & Flake8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,13 @@
 install:
   - pip install -U tox-travis codecov
   - npm install --cwd brew_view/static --prefix brew_view/static eslint eslint-config-google
-matrix:
-  include:
-    - language: python
-      python:
-        - 3.6
-        - 3.5
-        - 2.7
-      script:
-        - tox
-        - make -C brew_view/static/ lint
-      after_success:
-        codecov
+language: python
+python:
+  - 3.6
+  - 3.5
+  - 2.7
+script:
+  - tox
+  - make -C brew_view/static/ lint
+after_success:
+  codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,15 @@
-install: pip install -U tox-travis codecov
-language: python
-python:
-- 3.6
-- 3.5
-- 2.7
-script: tox
-after_success:
-  codecov
+install:
+  - pip install -U tox-travis codecov
+  - npm install --cwd brew_view/static --prefix brew_view/static eslint eslint-config-google
+matrix:
+  include:
+    - language: python
+      python:
+        - 3.6
+        - 3.5
+        - 2.7
+      script:
+        - tox
+        - make -C brew_view/static/ lint
+      after_success:
+        codecov

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,10 @@ clean-test: ## remove test and coverage artifacts
 lint: ## check style with flake8
 	flake8 $(MODULE_NAME) $(PYTHON_TEST_DIR)
 
+lint-all:
+	$(MAKE) lint
+	$(MAKE) -C $(JS_DIR) lint
+
 test: ## run tests quickly with the default Python
 	nosetests $(PYTHON_TEST_DIR)
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ MODULE_NAME   = brew_view
 PYTHON_TEST_DIR = test/unit
 JS_DIR = brew_view/static
 
-.PHONY: clean clean-build clean-test clean-pyc help test
+.PHONY: clean clean-build clean-test clean-pyc help test deps
 .DEFAULT_GOAL := help
 define BROWSER_PYSCRIPT
 import os, webbrowser, sys
@@ -68,7 +68,7 @@ test-all: ## run tests on every Python version with tox
 	tox
 
 coverage: ## check code coverage quickly with the default Python
-	coverage run --source $(MODULE_NAME) -m nose
+	coverage run --source $(MODULE_NAME) -m nose test/unit/
 	coverage report -m
 	coverage html
 	$(BROWSER) htmlcov/index.html
@@ -89,3 +89,7 @@ dist: clean ## builds source and wheel package
 
 install: clean ## install the package to the active Python's site-packages
 	python setup.py install
+
+deps:
+	pip install -r requirements.txt
+	$(MAKE) -C $(JS_DIR) deps

--- a/README.rst
+++ b/README.rst
@@ -38,28 +38,44 @@ Prerequisites
 * Python (2.7.9+ or 3.4+)
 * Node.js (Stable, 6+) with `yarn` installed globally
 * Connectivity to a MongoDB Server
+* Connectivity to a RabbitMQ Server
 
 Get Up and Running
 ------------------
 
-```bash
-# Clone the repository
-git clone https://github.com/beer-garden.git
-cd beer-garden/brew-view
+A full installation guide for RabbitMQ and Mongo is outside the scope of this document. Below is a small snippet to get you up and running if you have ``docker`` installed..
 
-# Install node dependencies and build frontend
-pushd brew_view/static
-yarn install && yarn build
-popd
+.. code-block:: console
 
-# Install Python dependencies
-pip install -r requirements.txt
+    $ docker run -d -p 27017:27017 --name bg-mongo mongo
+    $ docker run -d -p 5672:5672 -p 15672:15672 --name bg-rmq rabbitmq:3-management-alpine
 
-# Run the application
-bin/app.sh
-```
 
-Sweet! Everything should now be up and running. Visit http://localhost:2337/ in a browser to check it out. Hit Ctrl-c to stop the web server.
+To do development locally, it is important to note that brew-view is a combination of a python API powered by ``tornado`` and an AngularJS App. So we will start them both up!
+
+.. code-block:: console
+
+    $ git clone https://github.com/beer-garden/brew-view.git
+    $ cd brew-view
+    $ make deps # just a simple way to do pip install -r requirements.txt and yarn install
+
+Start up the JavaScript Application:
+
+.. code-block:: console
+
+    $ cd brew_view/static
+    $ yarn serve
+
+Now start up the Python API:
+
+.. code-block:: console
+
+    $ cd /path/to/brew-view
+    $ python -m brew_view -c ./dev_conf/config.json
+
+Sweet! Everything should now be up and running. Visit http://localhost:8080/ in a browser to check it out. Hit Ctrl-c to stop the web server.
+
+NOTE: It's worth noting that the JavaScript App is served on 8080 but the python application is running on 2337.
 
 
 Configuration
@@ -76,20 +92,57 @@ Brew-view's most visible job is to serve the frontend application, but it also p
 Testing and Code Coverage
 =========================
 
+You can run the testing yourself.
+
 Python
 ------
 
-```bash
-# In the 'brew-view' directory
-# To run the tests:
-nosetests
+.. code-block:: console
 
-# To generate code coverage:
-bin/generate_coverage.sh
-```
+    $ make test
 
-Running the code coverage script will:
-* Print results to STDOUT
-* Generate Cobertura and xUnit test result reports in the `output/python` directory
-* Generate an html report at `output/python/html/index.html`
+This will run the tests for the python application. You can run against multiple python versions using tox:
+
+.. code-block:: console
+
+    $ make test-all
+
+To generate coverage:
+
+.. code-block:: console
+
+    $ make coverage
+
+We use ``flake8`` for linting:
+
+.. code-block:: console
+
+    $ make lint
+
+JavaScript
+----------
+
+The JavaScript application has its own ``Makefile`` so to run these commands you'll need to be in the ``brew_view/static`` directory.
+
+We are currently lacking in good JavaScript tests since we switched to webpack. We are hoping to remedy this in the near-term future. You __should__ be able to run tests:
+
+.. code-block:: console
+
+    $ make test
+
+To run ESLint:
+
+.. code-block:: console
+
+    make lint
+
+Distribution
+============
+
+Creating the brew-view distribution is simple. Simply go to the git root directory and run the following:
+
+.. code-block:: console
+
+    $ make dist
+
 

--- a/brew_view/__main__.py
+++ b/brew_view/__main__.py
@@ -24,9 +24,9 @@ def shutdown():
     # Publish shutdown notification
     brew_view.event_publishers.publish_event(Event(name=Events.BREWVIEW_STOPPED.name))
 
-    # This is ... not great. Ideally we'd call shutdown() on event_publishers and it would be invoked on each of them.
-    # That's causing issues because we currently don't make a distinction between async an sync publishers, so for now
-    # just wait on the publisher we really care about
+    # This is ... not great. Ideally we'd call shutdown() on event_publishers and it would be
+    # invoked on each of them. That's causing issues because we currently don't make a distinction
+    # between async an sync publishers, so for now just wait on the publisher we really care about
     pika_shutdown_future = brew_view.event_publishers['pika'].shutdown()
 
     def do_stop(_):

--- a/brew_view/base_handler.py
+++ b/brew_view/base_handler.py
@@ -26,7 +26,8 @@ class BaseHandler(RequestHandler):
             DoesNotExist: {'status_code': 404, 'message': 'Resource does not exist'},
             NotUniqueError: {'status_code': 409, 'message': 'Resource already exists'},
 
-            bg_utils.bg_thrift.BaseException: {'status_code': 502, 'message': 'An error occurred on the backend'},
+            bg_utils.bg_thrift.BaseException: {'status_code': 502, 'message': 'An error occurred '
+                                                                              'on the backend'},
             TException: {'status_code': 503, 'message': 'Could not connect to Bartender'},
             socket.timeout: {'status_code': 504, 'message': 'Backend request timed out'},
         }
@@ -51,10 +52,11 @@ class BaseHandler(RequestHandler):
             content_type = content_type.split(';')
 
             self.request.mime_type = content_type[0]
-            if self.request.mime_type not in ['application/json', 'application/x-www-form-urlencoded']:
+            if self.request.mime_type not in ['application/json',
+                                              'application/x-www-form-urlencoded']:
                 raise BrewmasterModelValidationError('Unsupported or missing content-type header')
 
-            # Attempt to parse out the charset and decode the body for the handlers, default to utf-8
+            # Attempt to parse out the charset and decode the body, default to utf-8
             charset = 'utf-8'
             if len(content_type) > 1:
                 search_result = self.charset_re.search(content_type[1])
@@ -66,7 +68,8 @@ class BaseHandler(RequestHandler):
     def on_finish(self):
         """Called after a handler completes processing"""
         if self.request.event.name:
-            brew_view.event_publishers.publish_event(self.request.event, **self.request.event_extras)
+            brew_view.event_publishers.publish_event(self.request.event,
+                                                     **self.request.event_extras)
 
     def options(self, *args, **kwargs):
 
@@ -78,24 +81,27 @@ class BaseHandler(RequestHandler):
     def write_error(self, status_code, **kwargs):
         """Transform an exception into a response.
 
-        This protects controllers from having to write a lot of the same code over and over and over. Controllers can,
-        of course, overwrite error handlers and return their own responses if necessary, but generally, this is where
-        error handling should occur.
+        This protects controllers from having to write a lot of the same code over and over and
+        over. Controllers can, of course, overwrite error handlers and return their own responses
+        if necessary, but generally, this is where error handling should occur.
 
-        When an exception is handled this function makes two passes through error_map. The first pass is to see if the
-        exception type can be matched exactly. If there is no exact type match the second pass will attempt to match
-        using isinstance. If a message is provided in the error_map it takes precedence over the exception message.
+        When an exception is handled this function makes two passes through error_map. The first
+        pass is to see if the exception type can be matched exactly. If there is no exact type
+        match the second pass will attempt to match using isinstance. If a message is provided in
+        the error_map it takes precedence over the exception message.
 
-        ***NOTE*** Nontrivial inheritance trees will almost definitely break. This is a BEST EFFORT using a simple
-        isinstance check on an unordered data structure. So if an exception class has both a parent and a grandparent in
-        the error_map there is no guarantee about which message / status code will be chosen. The same applies to
-        exceptions that use multiple inheritance.
+        ***NOTE*** Nontrivial inheritance trees will almost definitely break. This is a BEST EFFORT
+        using a simple isinstance check on an unordered data structure. So if an exception class
+        has both a parent and a grandparent in the error_map there is no guarantee about which
+        message / status code will be chosen. The same applies to exceptions that use multiple
+        inheritance.
 
         ***LOGGING***
-        An exception raised in a controller method will generate logging to the tornado.application logger that
-        includes a stacktrace. That logging occurs before this method is invoked.
+        An exception raised in a controller method will generate logging to the tornado.application
+        logger that includes a stacktrace. That logging occurs before this method is invoked.
         The result of this method will generate logging to the tornado.access logger as usual.
-        So there is no need to do additional logging here as the 'real' exception will already have been logged.
+        So there is no need to do additional logging here as the 'real' exception will already have
+        been logged.
 
         :param status_code: a status_code that will be used if no match is found in the error map
         :return: None
@@ -124,7 +130,8 @@ class BaseHandler(RequestHandler):
                 message = str(e)
 
         code = code or 500
-        message = message or 'Encountered unknown exception. Please check with your System Administrator.'
+        message = message or ('Encountered unknown exception. Please check with your '
+                              'System Administrator.')
 
         self.request.event.error = True
         self.request.event.payload = {'message': message}

--- a/brew_view/controllers/__init__.py
+++ b/brew_view/controllers/__init__.py
@@ -1,3 +1,4 @@
+# flake8: noqa
 """Module to make imports of Controllers easier"""
 from brew_view.controllers.request_list_api import RequestListAPI
 from brew_view.controllers.request_api import RequestAPI
@@ -9,6 +10,7 @@ from brew_view.controllers.queue_list_api import QueueListAPI, OldQueueListAPI
 from brew_view.controllers.queue_api import QueueAPI, OldQueueAPI
 from brew_view.controllers.admin_api import AdminAPI, OldAdminAPI
 from brew_view.controllers.instance_api import InstanceAPI
-from brew_view.controllers.misc_controllers import ConfigHandler, VersionHandler, SpecHandler, SwaggerConfigHandler
+from brew_view.controllers.misc_controllers import ConfigHandler, VersionHandler, SpecHandler, \
+    SwaggerConfigHandler
 from brew_view.controllers.logging_api import LoggingConfigAPI
 from brew_view.controllers.event_api import EventPublisherAPI

--- a/brew_view/controllers/admin_api.py
+++ b/brew_view/controllers/admin_api.py
@@ -19,8 +19,8 @@ class AdminAPI(BaseHandler):
         ---
         summary: Initiate a rescan of the plugin directory
         description: |
-          The body of the request needs to contain a set of instructions detailing the operations to perform. Currently
-          the only operation supported is `rescan`:
+          The body of the request needs to contain a set of instructions detailing the operations
+          to perform. Currently the only operation supported is `rescan`:
           ```JSON
           {
             "operations": [
@@ -28,7 +28,8 @@ class AdminAPI(BaseHandler):
             ]
           }
           ```
-          * Will remove from the registry and database any currently stopped plugins who's directory has been removed.
+          * Will remove from the registry and database any currently stopped plugins who's
+            directory has been removed.
           * Will add and start any new plugin directories.
         parameters:
           - name: patch
@@ -71,7 +72,8 @@ class OldAdminAPI(BaseHandler):
           This endpoint is DEPRECATED - Use PATCH /api/v1/admin instead.
 
           Will initiate a rescan of the plugins directory.
-          * Will remove from the registry and database any currently stopped plugins who's directory has been removed.
+          * Will remove from the registry and database any currently stopped plugins who's
+            directory has been removed.
           * Will add and start any new plugin directories.
         responses:
           204:

--- a/brew_view/controllers/command_api.py
+++ b/brew_view/controllers/command_api.py
@@ -34,4 +34,5 @@ class CommandAPI(BaseHandler):
         """
         self.logger.debug("Getting Command: %s", command_id)
 
-        self.write(self.parser.serialize_command(Command.objects.get(id=str(command_id)), to_string=False))
+        self.write(self.parser.serialize_command(Command.objects.get(id=str(command_id)),
+                                                 to_string=False))

--- a/brew_view/controllers/command_list_api.py
+++ b/brew_view/controllers/command_list_api.py
@@ -32,9 +32,10 @@ class CommandListAPI(BaseHandler):
 
         self.set_header('Content-Type', 'application/json; charset=UTF-8')
         try:
-            self.write(self.parser.serialize_command(Command.objects.all(), many=True, to_string=True))
+            self.write(self.parser.serialize_command(Command.objects.all(), many=True,
+                                                     to_string=True))
         except mongoengine.errors.DoesNotExist as ex:
-            self.logger.error("Got an error while attempting to serialize commands. This error usually indicates "
+            self.logger.error("Got an error while attempting to serialize commands. "
+                              "This error usually indicates "
                               "there are orphans in the database.")
             raise mongoengine.errors.InvalidDocumentError(ex)
-

--- a/brew_view/controllers/instance_api.py
+++ b/brew_view/controllers/instance_api.py
@@ -46,7 +46,8 @@ class InstanceAPI(BaseHandler):
         """
         self.logger.debug("Getting Instance: %s", instance_id)
 
-        self.write(self.parser.serialize_instance(Instance.objects.get(id=instance_id), to_string=False))
+        self.write(self.parser.serialize_instance(Instance.objects.get(id=instance_id),
+                                                  to_string=False))
 
     @coroutine
     def patch(self, instance_id):
@@ -54,8 +55,8 @@ class InstanceAPI(BaseHandler):
         ---
         summary: Partially update an Instance
         description: |
-          The body of the request needs to contain a set of instructions detailing the updates to apply. Currently the
-          only operations are:
+          The body of the request needs to contain a set of instructions detailing the updates to
+          apply. Currently the only operations are:
 
           * initialize
           * start

--- a/brew_view/controllers/logging_api.py
+++ b/brew_view/controllers/logging_api.py
@@ -42,8 +42,8 @@ class LoggingConfigAPI(BaseHandler):
         ---
         summary: Reload the plugin logging configuration
         description: |
-          The body of the request needs to contain a set of instructions detailing the operation to make.
-          Currently supported operations are below:
+          The body of the request needs to contain a set of instructions detailing the operation
+          to make. Currently supported operations are below:
           ```JSON
           {
             "operations": [
@@ -79,4 +79,5 @@ class LoggingConfigAPI(BaseHandler):
                 raise BrewmasterModelValidationError('value', error_msg)
 
         self.set_status(200)
-        self.write(self.parser.serialize_logging_config(brew_view.plugin_logging_config, to_string=False))
+        self.write(self.parser.serialize_logging_config(brew_view.plugin_logging_config,
+                                                        to_string=False))

--- a/brew_view/controllers/misc_controllers.py
+++ b/brew_view/controllers/misc_controllers.py
@@ -12,9 +12,9 @@ class ConfigHandler(BaseHandler):
     def get(self):
         """Subset of configuration options that the frontend needs"""
         self.write({k: brew_view.config[k] for k in
-                    ['allow_unsafe_templates', 'application_name', 'amq_admin_port', 'amq_host', 'amq_port',
-                     'amq_virtual_host', 'backend_host', 'backend_port', 'db_host', 'db_name', 'db_port',
-                     'icon_default', 'debug_mode', 'url_prefix']})
+                    ['allow_unsafe_templates', 'application_name', 'amq_admin_port', 'amq_host',
+                     'amq_port', 'amq_virtual_host', 'backend_host', 'backend_port', 'db_host',
+                     'db_name', 'db_port', 'icon_default', 'debug_mode', 'url_prefix']})
 
 
 class VersionHandler(BaseHandler):

--- a/brew_view/controllers/queue_list_api.py
+++ b/brew_view/controllers/queue_list_api.py
@@ -62,7 +62,8 @@ class QueueListAPI(BaseHandler):
 
                 with thrift_context() as client:
                     try:
-                        queue_info = yield client.getQueueInfo(system.name, system.version, instance.name)
+                        queue_info = yield client.getQueueInfo(system.name, system.version,
+                                                               instance.name)
                         queue['name'] = queue_info.name
                         queue['size'] = queue_info.size
                     except Exception:

--- a/brew_view/controllers/request_api.py
+++ b/brew_view/controllers/request_api.py
@@ -46,8 +46,9 @@ class RequestAPI(BaseHandler):
         ---
         summary: Partially update a Request
         description: |
-          The body of the request needs to contain a set of instructions detailing the updates to apply. Currently the
-          only operation supported is `replace`, with paths `/status`, `/output`, and `/error_class`:
+          The body of the request needs to contain a set of instructions detailing the updates to
+          apply. Currently the only operation supported is `replace`, with paths `/status`,
+          `/output`, and `/error_class`:
           ```JSON
           {
             "operations": [
@@ -84,10 +85,10 @@ class RequestAPI(BaseHandler):
         req = Request.objects.get(id=request_id)
         operations = self.parser.parse_patch(self.request.decoded_body, many=True, from_string=True)
 
-        # We note the status before the operations, because it is possible for the operations to update
-        # the status of the request. In that case, because the updates are coming in in a single request
-        # it is okay to update the output or error_class. Ideally this would be handled correctly when
-        # we better integrate PatchOperations with their models.
+        # We note the status before the operations, because it is possible for the operations to
+        # update the status of the request. In that case, because the updates are coming in in a
+        # single request it is okay to update the output or error_class. Ideally this would be
+        # handled correctly when we better integrate PatchOperations with their models.
         status_before = req.status
 
         for op in operations:
@@ -111,8 +112,8 @@ class RequestAPI(BaseHandler):
                     req.output = op.value
                 elif op.path == '/error_class':
                     if status_before in Request.COMPLETED_STATUSES:
-                        raise BrewmasterModelValidationError("Cannot update error_class for a request "
-                                                             "that is already completed")
+                        raise BrewmasterModelValidationError("Cannot update error_class for a "
+                                                             "request that is already completed")
                     req.error_class = op.value
                     self.request.event.error = True
                 else:

--- a/brew_view/controllers/request_list_api.py
+++ b/brew_view/controllers/request_list_api.py
@@ -25,35 +25,55 @@ class RequestListAPI(BaseHandler):
         ---
         summary: Retrieve a page of all Requests
         description: |
-          This endpoint queries multiple requests at once. Because it's intended to be used with Datatables the query
-          parameters are ... complicated. Here are things to keep in mind:
+          This endpoint queries multiple requests at once. Because it's intended to be used with
+          Datatables the query parameters are ... complicated. Here are things to keep in mind:
 
-          * With no query parameters this endpoint will return the first 100 non-child requests. This can be controlled
-            by passing the `start` and `length` query parameters.
+          * With no query parameters this endpoint will return the first 100 non-child requests.
+            This can be controlled by passing the `start` and `length` query parameters.
 
-          * This endpoint does NOT return child request definitions. If you want to see child requests you must use the
-            /api/v1/requests/{request_id} endpoint.
+          * This endpoint does NOT return child request definitions. If you want to see child
+            requests you must use the /api/v1/requests/{request_id} endpoint.
 
-          * By default this endpoint also does not include child requests in the response. That is, if a request has a
-            non-null `parent` field it will not be included in the response array. Use the `include_children` query
-            parameter to change this behavior.
+          * By default this endpoint also does not include child requests in the response. That
+            is, if a request has a non-null `parent` field it will not be included in the response
+            array. Use the `include_children` query parameter to change this behavior.
 
-          To filter, search, and order you need to conform to how Datatables structures its query parameters.
+          To filter, search, and order you need to conform to how Datatables structures its query
+          parameters.
 
-          * To indicate fields that should be included in the response specify multiple `columns` query parameters:
+          * To indicate fields that should be included in the response specify multiple `columns`
+            query parameters:
           ```JSON
-          {"data":"command","name":"","searchable":true,"orderable":true,"search":{"value":"","regex":false}}
-          {"data":"system","name":"","searchable":true,"orderable":true,"search":{"value":"","regex":false}}
+          {
+            "data": "command",
+            "name": "",
+            "searchable": true,
+            "orderable": true,
+            "search": {"value":"","regex":false}
+          }
+          {
+            "data": "system",
+            "name": "",
+            "searchable": true,
+            "orderable": true,
+            "search": {"value": "","regex": false}
+          }
           ```
           * To filter a specific field set the value in the `search` key of its `column` definition:
           ```JSON
-          {"data":"status","name":"","searchable":true,"orderable":true,"search":{"value":"SUCCESS","regex":false}}
+          {
+            "data": "status",
+            "name": "",
+            "searchable": true,
+            "orderable": true,
+            "search": {"value": "SUCCESS", "regex":false}
+          }
           ```
 
-          * To sort by a field use the `order` parameter. The `column` value should be the index of the column to sort
-            and the `dir` value can be either "asc" or "desc."
+          * To sort by a field use the `order` parameter. The `column` value should be the index
+            of the column to sort and the `dir` value can be either "asc" or "desc."
           ```JSON
-          {"column":3,"dir":"asc"}
+          {"column": 3,"dir": "asc"}
           ```
 
           * To perform a text-based search across all fields use the `search` parameter:
@@ -154,8 +174,8 @@ class RequestListAPI(BaseHandler):
 
         # Sweet, we have data. Now setup some headers for the response
         response_headers = {
-            # These are a courtesy for non-datatables requests. We want people making a request with no headers to
-            # realize they probably aren't getting the full dataset
+            # These are a courtesy for non-datatables requests. We want people making a request
+            # with no headers to realize they probably aren't getting the full dataset
             'start': start,
             'length': len(requests),
 
@@ -170,7 +190,8 @@ class RequestListAPI(BaseHandler):
             self.add_header('Access-Control-Expose-Headers', key)
 
         self.set_header('Content-Type', 'application/json; charset=UTF-8')
-        self.write(self.parser.serialize_request(requests, to_string=True, many=True, only=requested_fields))
+        self.write(self.parser.serialize_request(requests, to_string=True, many=True,
+                                                 only=requested_fields))
 
     @coroutine
     def post(self):
@@ -210,7 +231,8 @@ class RequestListAPI(BaseHandler):
             args = {'parameters': {}}
             for key, value in self.request.body_arguments.items():
                 if key.startswith('parameters.'):
-                    args['parameters'][key.replace('parameters.', '')] = value[0].decode(self.request.charset)
+                    args['parameters'][key.replace('parameters.', '')] = value[0].decode(
+                        self.request.charset)
                 else:
                     args[key] = value[0].decode(self.request.charset)
             request_model = Request(**args)
@@ -244,14 +266,17 @@ class RequestListAPI(BaseHandler):
             # Since request has system info we can query for a system object
             system = System.objects.get(name=req.system, version=req.system_version)
 
-            # Loop through all instances in the system until we find the instance that matches the request instance
+            # Loop through all instances in the system until we find the instance that matches
+            # the request instance
             for instance in system.instances:
                 if instance.name == req.instance_name:
                     self.set_header("Instance-Status", instance.status)
 
-        # The Request is already created at this point so adding the Instance status header is a best-effort thing
+        # The Request is already created at this point so adding the Instance status header is a
+        # best-effort thing
         except Exception as ex:
-            self.logger.exception('Unable to get Instance status for Request %s: %s', str(request_model.id), ex)
+            self.logger.exception('Unable to get Instance status for Request %s: %s',
+                                  str(request_model.id), ex)
 
         self.request.event_extras = {'request': req}
 
@@ -295,7 +320,8 @@ class RequestListAPI(BaseHandler):
                     else:
                         search_query = Q(**{column['data']+'__contains': column['search']['value']})
 
-                        # Little hacky but whatever, need this because we combine system and instance in the same column
+                        # Little hacky but whatever, need this because we combine system and
+                        # instance in the same column
                         if column['data'] == 'system':
                             search_query |= Q(instance_name__contains=column['search']['value'])
 

--- a/brew_view/controllers/system_api.py
+++ b/brew_view/controllers/system_api.py
@@ -45,19 +45,20 @@ class SystemAPI(BaseHandler):
         """
         self.logger.debug("Getting System: %s", system_id)
 
-        include_commands = self.get_query_argument('include_commands', default='true').lower() != 'false'
+        include_commands = self.get_query_argument(
+            'include_commands', default='true').lower() != 'false'
         self.write(self.parser.serialize_system(System.objects.get(id=system_id), to_string=False,
                                                 include_commands=include_commands))
 
     @coroutine
     def delete(self, system_id):
         """
-        Will give Bartender a chance to remove instances of this system from the registry but will always delete the
-        system regardless of whether the Bartender operation succeeds.
+        Will give Bartender a chance to remove instances of this system from the registry but will
+        always delete the system regardless of whether the Bartender operation succeeds.
         ---
         summary: Delete a specific System
-        description: Will remove instances of local plugins from the registry, clear and remove message queues, and
-          remove the system from the database.
+        description: Will remove instances of local plugins from the registry, clear and remove
+            message queues, and remove the system from the database.
         parameters:
           - name: system_id
             in: path
@@ -88,7 +89,8 @@ class SystemAPI(BaseHandler):
         ---
         summary: Partially update a System
         description: |
-          The body of the request needs to contain a set of instructions detailing the updates to apply.
+          The body of the request needs to contain a set of instructions detailing the updates to
+          apply.
           Currently supported operations are below:
           ```JSON
           {
@@ -139,7 +141,8 @@ class SystemAPI(BaseHandler):
                     new_commands = self.parser.parse_command(op.value, many=True)
                     if system.has_different_commands(new_commands):
                         if system.commands and 'dev' not in system.version:
-                            raise BrewmasterModelValidationError('System %s-%s already exists with different commands' %
+                            raise BrewmasterModelValidationError('System %s-%s already exists with '
+                                                                 'different commands' %
                                                                  (system.name, system.version))
                         else:
                             system.upsert_commands(new_commands)

--- a/brew_view/specification.py
+++ b/brew_view/specification.py
@@ -181,7 +181,8 @@ SPECIFICATION = {
     },
     "plugin_log_level": {
         "type": "str",
-        "description": "Default log level for plugins (could be overwritten by plugin_log_config value)",
+        "description": "Default log level for plugins (could be "
+                       "overwritten by plugin_log_config value)",
         "default": "INFO",
         "choices": ["DEBUG", "INFO", "WARN", "WARNING", "ERROR", "CRITICAL"]
     },

--- a/brew_view/static/.eslintignore
+++ b/brew_view/static/.eslintignore
@@ -1,0 +1,2 @@
+dist
+node_modules

--- a/brew_view/static/.eslintrc.json
+++ b/brew_view/static/.eslintrc.json
@@ -1,0 +1,14 @@
+{
+    "extends": "google",
+    "rules": {
+      "max-len": [2, 100, 4]
+    },
+    "env": {
+      "mocha": true,
+      "es6": true
+    },
+    "parserOptions": {
+      "ecmaVersion": 6,
+      "sourceType": "module"
+    }
+}

--- a/brew_view/static/Makefile
+++ b/brew_view/static/Makefile
@@ -4,7 +4,7 @@ MODULE_NAME   = brew_view
 PYTHON_TEST_DIR = test/unit
 JS_DIR = brew_view/static
 
-.PHONY: clean clean-build clean-test help test
+.PHONY: clean clean-build clean-test help test deps
 .DEFAULT_GOAL := help
 define BROWSER_PYSCRIPT
 import os, webbrowser, sys
@@ -52,3 +52,6 @@ coverage: ## check code coverage
 
 dist: clean ## builds distribution
 	npm run build
+
+deps: ## install javascript dependencies
+	yarn install

--- a/brew_view/static/Makefile
+++ b/brew_view/static/Makefile
@@ -42,7 +42,7 @@ clean-test: ## remove test and coverage artifacts
 	rm -f yarn-error.log
 
 lint: ## check style with eslit
-	echo "TODO: run ESLint"
+	npm run lint
 
 test: ## run tests
 	echo "TODO: run javascript tests"
@@ -52,4 +52,3 @@ coverage: ## check code coverage
 
 dist: clean ## builds distribution
 	npm run build
-

--- a/brew_view/static/index.html
+++ b/brew_view/static/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang='en' ng-app="bgApp">
   <head>
-    <title ng-bind="config.application_name"></title>
+    <title ng-bind="config.applicationName"></title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" charset="utf-8">
 
     <link href="dist/vendor.css" rel="stylesheet">
@@ -9,7 +9,7 @@
     <link ng-if="themes.slate" ng-href="dist/dark.css" rel="stylesheet">
 
     <!-- Favicon -->
-    <link ng-if="config.icon_default" ng-href="dist/image/{{config.icon_default}}.png" rel="shortcut icon">
+    <link ng-if="config.iconDefault" ng-href="dist/image/{{config.iconDefault}}.png" rel="shortcut icon">
   </head>
 
   <body ng-cloak ng-controller="ApplicationController">
@@ -25,8 +25,8 @@
           <span class='icon-bar'></span>
         </button>
         <a class="navbar-brand" href="#/">
-          <i ng-class="getIcon(config.icon_default)"></i>
-          <span ng-cloak>{{config.application_name}}</span>
+          <i ng-class="getIcon(config.iconDefault)"></i>
+          <span ng-cloak>{{config.applicationName}}</span>
         </a>
       </div>
 

--- a/brew_view/static/package.json
+++ b/brew_view/static/package.json
@@ -41,6 +41,9 @@
     "ui-select": "^0.19.8"
   },
   "devDependencies": {
+    "babel-core": "^6.26.0",
+    "babel-loader": "^7.1.2",
+    "babel-preset-env": "^1.6.1",
     "chai": "^4.1.2",
     "copy-webpack-plugin": "^4.4.1",
     "css-loader": "^0.28.4",

--- a/brew_view/static/package.json
+++ b/brew_view/static/package.json
@@ -44,6 +44,9 @@
     "chai": "^4.1.2",
     "copy-webpack-plugin": "^4.4.1",
     "css-loader": "^0.28.4",
+    "eslint": "^4.17.0",
+    "eslint-config-google": "^0.9.1",
+    "eslint-loader": "^1.9.0",
     "extract-text-webpack-plugin": "^3.0.0",
     "file-loader": "^1.1.5",
     "html-loader": "^0.5.0",
@@ -75,7 +78,8 @@
     "watch": "webpack --watch --config webpack.dev.js",
     "serve": "webpack-dev-server --config webpack.dev.js",
     "pretest": "rm -rf output/js/",
-    "test": "grunt test:jenkins"
+    "lint": "eslint src/",
+    "test": "karma start karma-conf.js --single-run"
   },
   "repository": {
     "type": "git",

--- a/brew_view/static/src/index.js
+++ b/brew_view/static/src/index.js
@@ -30,7 +30,7 @@ import 'datatables.net';
 import 'datatables.net-bs';
 import 'datatables-light-columnfilter';
 import 'angular-datatables/dist/angular-datatables.js';
-import 'angular-datatables/dist/plugins/light-columnfilter/angular-datatables.light-columnfilter.js';
+import 'angular-datatables/dist/plugins/light-columnfilter/angular-datatables.light-columnfilter.js'; // eslint-disable-line max-len
 import 'angular-datatables/dist/plugins/bootstrap/angular-datatables.bootstrap.js';
 import 'angular-schema-form-bootstrap/dist/angular-schema-form-bootstrap-bundled.js';
 import 'ace-builds/src-noconflict/ace.js';
@@ -73,7 +73,7 @@ import requestService from './js/services/request_service.js';
 import systemService from './js/services/system_service.js';
 import utilityService from './js/services/utility_service.js';
 import versionService from './js/services/version_service.js';
-import {sfPostProcessor, sfErrorMessageConfig, sfBuilderService} from './js/services/sf_builder_service.js';
+import {sfPostProcessor, sfErrorMessageConfig, sfBuilderService} from './js/services/sf_builder_service.js'; // eslint-disable-line max-len
 
 import aboutController from './js/controllers/about.js';
 import adminQueueController from './js/controllers/admin_queue.js';
@@ -117,7 +117,7 @@ angular.module('bgApp',
   'ngAnimate',
   'frapontillo.bootstrap-switch',
   'mgcrea.ngStrap',
-  'ngCookies'
+  'ngCookies',
 ])
 .run(appRun)
 .run(sfPostProcessor)

--- a/brew_view/static/src/js/configs/http_interceptor.js
+++ b/brew_view/static/src/js/configs/http_interceptor.js
@@ -1,10 +1,17 @@
 
 interceptorService.$inject = ['$rootScope', '$templateCache'];
+
+/**
+ * interceptorService - Used to intercept API requests.
+ * @param  {$rootScope} $rootScope         Angular's $rootScope object.
+ * @param  {$templateCache} $templateCache Angular's $templateCache object.
+ */
 export function interceptorService($rootScope, $templateCache) {
-  var service = this;
+  /* eslint-disable no-invalid-this */
+  let service = this;
   service.request = function(config) {
     // Only match things that we know are targeted at our backend
-    if($rootScope.apiBaseUrl && (config.url.startsWith('config') ||
+    if ($rootScope.apiBaseUrl && (config.url.startsWith('config') ||
         config.url.startsWith('version') || config.url.startsWith('api'))) {
       config.url = $rootScope.apiBaseUrl + config.url;
     }
@@ -13,6 +20,11 @@ export function interceptorService($rootScope, $templateCache) {
 };
 
 interceptorConfig.$inject = ['$httpProvider'];
-export function interceptorConfig($httpProvider){
+
+/**
+ * interceptorConfig - Angular configuration object for API interceptors.
+ * @param  {$httpProvider} $httpProvider Angular's $httpProvider object.
+ */
+export function interceptorConfig($httpProvider) {
   $httpProvider.interceptors.push('APIInterceptor');
 };

--- a/brew_view/static/src/js/configs/routes.js
+++ b/brew_view/static/src/js/configs/routes.js
@@ -1,57 +1,63 @@
 
 routeConfig.$inject = ['$stateProvider', '$urlRouterProvider'];
-export default function routeConfig($stateProvider, $urlRouterProvider) {
-  var basePath = 'partials/';
 
-  $urlRouterProvider.otherwise("/");
+/**
+ * routeConfig - routing config for the application.
+ * @param  {type} $stateProvider     Angular's $stateProvider object.
+ * @param  {type} $urlRouterProvider Angular's $urlRouterProvider object.
+ */
+export default function routeConfig($stateProvider, $urlRouterProvider) {
+  const basePath = 'partials/';
+
+  $urlRouterProvider.otherwise('/');
 
   $stateProvider
     .state('landing', {
         url: '/',
         templateUrl: basePath + 'landing.html',
-        controller: 'LandingController'
+        controller: 'LandingController',
     })
     .state('system', {
       url: '/systems/:id',
       templateUrl: basePath + 'system_view.html',
-      controller: 'SystemViewController'
+      controller: 'SystemViewController',
     })
     .state('about', {
       url: '/about',
       templateUrl: basePath + 'about.html',
-      controller: 'AboutController'
+      controller: 'AboutController',
     })
     .state('queues', {
       url: '/admin/queues',
       templateUrl: basePath + 'admin_queue.html',
-      controller: 'QueueIndexController'
+      controller: 'QueueIndexController',
     })
     .state('commands', {
       url: '/commands',
       templateUrl: basePath + 'command_index.html',
-      controller: 'CommandIndexController'
+      controller: 'CommandIndexController',
     })
     .state('command', {
       url: '/commands/:command_id',
       templateUrl: basePath + 'command_view.html',
       controller: 'CommandViewController',
       params: {
-        request: null
-      }
+        request: null,
+      },
     })
     .state('requests', {
       url: '/requests',
       templateUrl: basePath + 'request_index.html',
-      controller: 'RequestIndexController'
+      controller: 'RequestIndexController',
     })
     .state('request', {
       url: '/requests/:request_id',
       templateUrl: basePath + 'request_view.html',
-      controller: 'RequestViewController'
+      controller: 'RequestViewController',
     })
     .state('system_admin', {
       url: '/admin/systems',
       templateUrl: basePath + 'admin_system.html',
-      controller: 'SystemAdminController'
+      controller: 'SystemAdminController',
     });
 };

--- a/brew_view/static/src/js/controllers/about.js
+++ b/brew_view/static/src/js/controllers/about.js
@@ -1,5 +1,11 @@
 
 AboutController.$inject = ['$scope', 'VersionService'];
+
+/**
+ * AboutController - Angular controller for the about page.
+ * @param  {$scope} $scope         Angular's $scope object.
+ * @param  {Object} VersionService Beer-Garden's version service object.
+ */
 export default function AboutController($scope, VersionService) {
   $scope.version = {
     data: {},
@@ -7,18 +13,19 @@ export default function AboutController($scope, VersionService) {
     error: false,
     errorMessage: '',
     errorMap: {
-      'empty' : {
-        'solutions' : [
+      'empty': {
+        'solutions': [
           {
-            problem     : 'Could not get version information',
-            description : 'The web service is down. Odd that you can still get to this page, right?' +
-                          'You should probably restart the service. If other pages are still running ' +
-                          'after a hard refresh (ctrl-F5) then you should contact a developer.',
-            resolution  : '<kbd>service brew-view restart</kbd>'
-          }
-        ]
-      }
-    }
+            problem: 'Could not get version information',
+            description: 'The web service is down. Odd that you can still get to this page, ' +
+                         'right? You should probably restart the service. If other pages are ' +
+                         'still running after a hard refresh (ctrl-F5) then you should contact ' +
+                         'a developer.',
+            resolution: '<kbd>service brew-view restart</kbd>',
+          },
+        ],
+      },
+    },
   };
 
   $scope.successCallback = function(response) {
@@ -26,14 +33,14 @@ export default function AboutController($scope, VersionService) {
     $scope.version.loaded = true;
     $scope.version.error = false;
     $scope.version.errorMessage = '';
-  }
+  },
 
   $scope.failureCallback = function(response) {
     $scope.version.data = {};
     $scope.version.loaded = false;
     $scope.version.error = true;
     $scope.version.errorMessage = response.data.message;
-  }
+  },
 
   VersionService.getVersionInfo().then($scope.successCallback, $scope.failureCallback);
 };

--- a/brew_view/static/src/js/controllers/admin_system.js
+++ b/brew_view/static/src/js/controllers/admin_system.js
@@ -1,7 +1,36 @@
 import angular from 'angular';
 
-systemAdminController.$inject = ['$scope', '$rootScope', '$interval', '$http', 'SystemService', 'InstanceService', 'UtilityService', 'AdminService'];
-export default function systemAdminController($scope, $rootScope, $interval, $http, SystemService, InstanceService, UtilityService, AdminService) {
+systemAdminController.$inject = [
+  '$scope',
+  '$rootScope',
+  '$interval',
+  '$http',
+  'SystemService',
+  'InstanceService',
+  'UtilityService',
+  'AdminService',
+];
+
+/**
+ * systemAdminController - System management controller.
+ * @param  {$scope} $scope          Angular's $scope object.
+ * @param  {$rootScope} $rootScope  Angular's $rootScope object.
+ * @param  {$interval} $interval    Angular's $interval object.
+ * @param  {$http} $http            Angular's $http object.
+ * @param  {Object} SystemService   Beer-Garden's system service object.
+ * @param  {Object} InstanceService Beer-Garden's instance service object.
+ * @param  {Object} UtilityService  Beer-Garden's utility service object.
+ * @param  {Object} AdminService    Beer-Garden's admin service object.
+ */
+export default function systemAdminController(
+  $scope,
+  $rootScope,
+  $interval,
+  $http,
+  SystemService,
+  InstanceService,
+  UtilityService,
+  AdminService) {
   $scope.util = UtilityService;
 
   $scope.systems = {
@@ -13,36 +42,37 @@ export default function systemAdminController($scope, $rootScope, $interval, $ht
     status: null,
     errorMap: {
       'empty': {
-        'solutions' : [
+        'solutions': [
           {
-            problem     : 'Backend Down',
-            description : 'If the backend is down, there will be no systems to control',
-            resolution  : '<kbd>service bartender start</kbd>'
+            problem: 'Backend Down',
+            description: 'If the backend is down, there will be no systems to control',
+            resolution: '<kbd>service bartender start</kbd>',
           },
           {
-            problem     : 'Plugin Problems',
-            description : 'If Plugins attempted to start, but are failing to startup, then' +
-                          'you\'ll have to contact the plugin maintainer. You can tell what\'s wrong ' +
-                          'by their logs. Plugins are located at <code>$APP_HOME/plugins</code>',
-            resolution  : '<kbd>less $APP_HOME/log/my-plugin.log</kbd>'
+            problem: 'Plugin Problems',
+            description: 'If Plugins attempted to start, but are failing to startup, then' +
+                         'you\'ll have to contact the plugin maintainer. You can tell what\'s ' +
+                         'wrong by their logs. Plugins are located at ' +
+                         '<code>$APP_HOME/plugins</code>',
+            resolution: '<kbd>less $APP_HOME/log/my-plugin.log</kbd>',
           },
           {
-            problem     : 'Database Names Do Not Match',
-            description : 'It is possible that the backend is pointing to a Different Database than ' +
-                          'the Frontend. Check to make sure that the <code>DB_NAME</code> in both ' +
-                          'config files is the same',
-            resolution  : '<kbd>vim $APP_HOME/conf/bartender.json</kbd><br />' +
-                          '<kbd>vim $APP_HOME/conf/brew-view.json</kbd>'
+            problem: 'Database Names Do Not Match',
+            description: 'It is possible that the backend is pointing to a Different Database ' +
+                         'than the Frontend. Check to make sure that the <code>DB_NAME</code> ' +
+                         'in both config files is the same',
+            resolution: '<kbd>vim $APP_HOME/conf/bartender.json</kbd><br />' +
+                        '<kbd>vim $APP_HOME/conf/brew-view.json</kbd>',
           },
           {
-            problem     : 'There Are No Systems',
-            description : 'If no one has ever developed any plugins, then there will be no systems ' +
-                          'here. You\'ll need to build your own plugins.',
-            resolution  : 'Develop a Plugin'
-          }
-        ]
-      }
-    }
+            problem: 'There Are No Systems',
+            description: 'If no one has ever developed any plugins, then there will be no ' +
+                          'systems here. You\'ll need to build your own plugins.',
+            resolution: 'Develop a Plugin',
+          },
+        ],
+      },
+    },
   };
 
   $scope.rescan = function() {
@@ -50,14 +80,14 @@ export default function systemAdminController($scope, $rootScope, $interval, $ht
   };
 
   $scope.startSystem = function(system) {
-    for(var i=0; i<system.instances.length; i++) {
+    for (let i=0; i<system.instances.length; i++) {
       system.instances[i].status = 'STARTING';
       InstanceService.startInstance(system.instances[i]);
     }
   };
 
   $scope.stopSystem = function(system) {
-    for(var i=0; i<system.instances.length; i++) {
+    for (let i=0; i<system.instances.length; i++) {
       system.instances[i].status = 'STOPPING';
       InstanceService.stopInstance(system.instances[i]);
     }
@@ -89,23 +119,23 @@ export default function systemAdminController($scope, $rootScope, $interval, $ht
   };
 
   // Register a function that polls for system status
-  var status_update = $interval(function() {
+  let statusUpdate = $interval(function() {
     SystemService.getSystems().then($scope.successCallback, $scope.failureCallback);
   }, 5000);
 
   $scope.$on('$destroy', function() {
-    if(angular.isDefined(status_update)) {
-      $interval.cancel(status_update);
-      status_update = undefined;
+    if (angular.isDefined(statusUpdate)) {
+      $interval.cancel(statusUpdate);
+      statusUpdate = undefined;
     }
   });
 
-  var groupSystems = function(rawSystems) {
-    var systems = {};
-    for(var i=0; i<rawSystems.length; i++) {
-      var system = rawSystems[i];
-      var systemName = system.display_name || system.name;
-      if(!(systemName in systems)) {
+  let groupSystems = function(rawSystems) {
+    let systems = {};
+    for (let i=0; i<rawSystems.length; i++) {
+      let system = rawSystems[i];
+      let systemName = system.display_name || system.name;
+      if (!(systemName in systems)) {
         systems[systemName] = {};
       }
       systems[systemName][system.version] = system;
@@ -123,10 +153,10 @@ export default function systemAdminController($scope, $rootScope, $interval, $ht
     $scope.systems.data = groupSystems(response.data);
 
     // Extra kick for the 'empty' directive
-    if(Object.keys($scope.systems.data).length === 0) {
+    if (Object.keys($scope.systems.data).length === 0) {
       $scope.systems.status = 404;
     }
-  }
+  };
 
   $scope.failureCallback = function(response) {
     $scope.systems.data = [];
@@ -134,7 +164,7 @@ export default function systemAdminController($scope, $rootScope, $interval, $ht
     $scope.systems.error = true;
     $scope.systems.status = response.status;
     $scope.systems.errorMessage = response.data.message;
-  }
+  };
 
   SystemService.getSystems().then($scope.successCallback, $scope.failureCallback);
 };

--- a/brew_view/static/src/js/controllers/application.js
+++ b/brew_view/static/src/js/controllers/application.js
@@ -1,4 +1,10 @@
 applicationController.$inject = ['$scope', 'UtilityService'];
+
+/**
+ * applicationController - Base Application controller.
+ * @param  {$scope} $scope         Angular's $scope object.
+ * @param  {Object} UtilityService Beer-Garden's Utility Service.
+ */
 export default function applicationController($scope, UtilityService) {
   $scope.getIcon = UtilityService.getIcon;
 };

--- a/brew_view/static/src/js/controllers/command_index.js
+++ b/brew_view/static/src/js/controllers/command_index.js
@@ -1,6 +1,26 @@
 
-commandIndexController.$inject = ['$scope', 'SystemService', 'CommandService', 'UtilityService', 'DTOptionsBuilder'];
-export default function commandIndexController($scope, SystemService, CommandService, UtilityService, DTOptionsBuilder) {
+commandIndexController.$inject = [
+  '$scope',
+  'SystemService',
+  'CommandService',
+  'UtilityService',
+  'DTOptionsBuilder',
+];
+
+/**
+ * commandIndexController - Angular controller for all commands page.
+ * @param  {$scope} $scope           Angular's $scope object.
+ * @param  {Object} SystemService    Beer-Garden system service.
+ * @param  {Object} CommandService   Beer-Garden command service.
+ * @param  {Object} UtilityService   Beer-Garden utility service.
+ * @param  {Object} DTOptionsBuilder Data-tables' builder for options.
+ */
+export default function commandIndexController(
+  $scope,
+  SystemService,
+  CommandService,
+  UtilityService,
+  DTOptionsBuilder) {
   $scope.service = CommandService;
   $scope.util = UtilityService;
 
@@ -11,37 +31,38 @@ export default function commandIndexController($scope, SystemService, CommandSer
     error: false,
     errorMessage: '',
     errorMap: {
-      'empty' : {
-        'solutions' : [
+      'empty': {
+        'solutions': [
           {
-            problem     : 'Backend Down',
-            description : 'If the backend is down, there will be no commands to control',
-            resolution  : '<kbd>service bartender start</kbd>'
+            problem: 'Backend Down',
+            description: 'If the backend is down, there will be no commands to control',
+            resolution: '<kbd>service bartender start</kbd>',
           },
           {
-            problem     : 'Plugin Problems',
-            description : 'If Plugins attempted to start, but are failing to startup, then' +
-                          'you\'ll have to contact the plugin maintainer. You can tell what\'s '+
-                          'wrong by their logs. Plugins are located at <code>$APP_HOME/plugins</code>',
-            resolution  : '<kbd>less $APP_HOME/log/my-plugin.log</kbd>'
+            problem: 'Plugin Problems',
+            description: 'If Plugins attempted to start, but are failing to startup, then' +
+                         'you\'ll have to contact the plugin maintainer. You can tell what\'s '+
+                         'wrong by their logs. Plugins are located at ' +
+                         '<code>$APP_HOME/plugins</code>',
+            resolution: '<kbd>less $APP_HOME/log/my-plugin.log</kbd>',
           },
           {
-            problem     : 'Database Names Do Not Match',
-            description : 'It is possible that the backend is pointing to a Different Database than ' +
-                          'the Frontend. Check to make sure that the <code>DB_NAME</code> in both ' +
-                          'config files is the same',
-            resolution  : '<kbd>vim $APP_HOME/conf/bartender.json</kbd><br />' +
-                          '<kbd>vim $APP_HOME/conf/brew-view.json</kbd>'
+            problem: 'Database Names Do Not Match',
+            description: 'It is possible that the backend is pointing to a Different Database ' +
+                         'than the Frontend. Check to make sure that the <code>DB_NAME</code> ' +
+                         'in both config files is the same',
+            resolution: '<kbd>vim $APP_HOME/conf/bartender.json</kbd><br />' +
+                        '<kbd>vim $APP_HOME/conf/brew-view.json</kbd>',
           },
           {
-            problem     : 'There Are No Commands',
-            description : 'If no one has ever developed any plugins, then there will be no systems ' +
-                          'here. You\'ll need to build your own plugins.',
-            resolution  : 'Develop a Plugin'
-          }
-        ]
-      }
-    }
+            problem: 'There Are No Commands',
+            description: 'If no one has ever developed any plugins, then there will be no ' +
+                         'systems here. You\'ll need to build your own plugins.',
+            resolution: 'Develop a Plugin',
+          },
+        ],
+      },
+    },
   };
 
   $scope.dtOptions = DTOptionsBuilder.newOptions()
@@ -51,12 +72,11 @@ export default function commandIndexController($scope, SystemService, CommandSer
 
   $scope.successCallback = function(response) {
     // Make sure systems load before moving on with the sorting
-    if($scope.systems == null){
-      $scope.$on('systemsLoaded', function(){
+    if ($scope.systems == null) {
+      $scope.$on('systemsLoaded', function() {
         response.data.sort(CommandService.comparison);
       });
-    }
-    else{
+    } else {
       response.data.sort(CommandService.comparison);
     }
 
@@ -65,7 +85,7 @@ export default function commandIndexController($scope, SystemService, CommandSer
     $scope.commands.status = response.status;
     $scope.commands.error = false;
     $scope.commands.errorMessage = '';
-  }
+  };
 
   $scope.failureCallback = function(response) {
     $scope.commands.data = [];
@@ -73,7 +93,7 @@ export default function commandIndexController($scope, SystemService, CommandSer
     $scope.commands.error = true;
     $scope.commands.status = response.status;
     $scope.commands.errorMessage = response.data.message;
-  }
+  };
 
   CommandService.getCommands().then($scope.successCallback, $scope.failureCallback);
 };

--- a/brew_view/static/src/js/controllers/command_view.js
+++ b/brew_view/static/src/js/controllers/command_view.js
@@ -1,25 +1,59 @@
 import angular from 'angular';
 
-commandViewController.$inject = ['$location', '$scope', '$state', '$stateParams', '$sce', 'CommandService',
-   'RequestService', 'SystemService', 'SFBuilderService', 'UtilityService'];
-export default function commandViewController($location, $scope, $state, $stateParams, $sce, CommandService,
-    RequestService, SystemService, SFBuilderService, UtilityService ) {
-  $scope.schema         = {};
-  $scope.form           = [];
-  $scope.model          = $stateParams.request || {};
-  $scope.createError    = false;
-  $scope.alerts         = [];
-  $scope.baseModel      = {};
-  $scope.system         = {};
-  $scope.template       = '';
+commandViewController.$inject = [
+  '$location',
+  '$scope',
+  '$state',
+  '$stateParams',
+  '$sce',
+  'CommandService',
+  'RequestService',
+  'SystemService',
+  'SFBuilderService',
+  'UtilityService',
+];
+
+
+/**
+ * commandViewController - Angular controller for a specific command.
+ * @param  {$location} $location       Angular's $location object.
+ * @param  {$scope} $scope             Angular's $scope object.
+ * @param  {$state} $state             Angular's $state object.
+ * @param  {$stateParams} $stateParams Angular's $stateParams object.
+ * @param  {$sce} $sce                 Angular's $sce object.
+ * @param  {Object} CommandService     Beer-Garden's command service object.
+ * @param  {Object} RequestService     Beer-Garden's request service object.
+ * @param  {Object} SystemService      Beer-Garden's system service object.
+ * @param  {Object} SFBuilderService   Beer-Garden's schema-form builder service object.
+ * @param  {Object} UtilityService     Beer-Garden's utility service object.
+ */
+export default function commandViewController(
+  $location,
+  $scope,
+  $state,
+  $stateParams,
+  $sce,
+  CommandService,
+  RequestService,
+  SystemService,
+  SFBuilderService,
+  UtilityService ) {
+  $scope.schema = {};
+  $scope.form = [];
+  $scope.model = $stateParams.request || {};
+  $scope.createError = false;
+  $scope.alerts = [];
+  $scope.baseModel = {};
+  $scope.system = {};
+  $scope.template = '';
   $scope.manualOverride = false;
-  $scope.manualModel    = '';
+  $scope.manualModel = '';
 
   $scope.jsonValues = {
-    model: "",
-    command: "",
-    schema: "",
-    form: ""
+    model: '',
+    command: '',
+    schema: '',
+    form: '',
   };
 
   $scope.command = {
@@ -29,59 +63,61 @@ export default function commandViewController($location, $scope, $state, $stateP
     error: false,
     errorMessage: '',
     errorMap: {
-      'empty' : {
-        'solutions' : [
+      'empty': {
+        'solutions': [
           {
-            problem     : 'ID is incorrect',
-            description : 'The Backend has restarted and the ID changed of the command you were looking at',
-            resolution  : 'Click the ' + $scope.config.application_name + ' logo at the top left and refresh the page'
+            problem: 'ID is incorrect',
+            description: 'The Backend has restarted and the ID changed of the command you were ' +
+                         'looking at',
+            resolution: 'Click the ' + $scope.config.applicationName + ' logo at the top left ' +
+                        'and refresh the page',
           },
           {
-            problem     : 'The Plugin Stopped',
-            description : 'The plugin could have been stopped. You should probably contact the plugin ' +
-                          'maintainer. You should be able to tell what\'s wrong by their logs. Plugins' +
-                          ' are located at <code>$APP_HOME/plugins</code>',
-            resolution  : '<kbd>less $APP_HOME/log/my-plugin.log</kbd>'
-          }
-        ]
-      }
-    }
+            problem: 'The Plugin Stopped',
+            description: 'The plugin could have been stopped. You should probably contact the ' +
+                         'plugin maintainer. You should be able to tell what\'s wrong by their ' +
+                         'logs. Plugins are located at <code>$APP_HOME/plugins</code>',
+            resolution: '<kbd>less $APP_HOME/log/my-plugin.log</kbd>',
+          },
+        ],
+      },
+    },
   };
 
-  $scope.createRequestWrapper = function(requestPrototype) {
-    var request = {
+  $scope.createRequestWrapper = function(requestPrototype, ...args) {
+    let request = {
       command: requestPrototype['command'],
       system: requestPrototype['system'] || $scope.system.name,
       system_version: requestPrototype['system_version'] || $scope.system.version,
-      instance_name: requestPrototype['instance_name'] || 'default'
+      instance_name: requestPrototype['instance_name'] || 'default',
     };
 
     // If parameters are specified we need to use the model value
-    if(angular.isDefined(requestPrototype['parameterNames'])) {
+    if (angular.isDefined(requestPrototype['parameterNames'])) {
       request['parameters'] = {};
-      var nameList = requestPrototype['parameterNames'];
-      for(var i=0; i<nameList.length; i++) {
-        request['parameters'][nameList[i]] = arguments[i+1]; // Skip the requestPrototype
+      let nameList = requestPrototype['parameterNames'];
+      for (let i=0; i<nameList.length; i++) {
+        request['parameters'][nameList[i]] = args[i+1]; // Skip the requestPrototype
       };
     }
 
     return RequestService.createRequestWait(request).then(
-      function(response) { return response.data; }
+      function(response) {
+        return response.data;
+      }
     );
   };
 
-  $scope.checkInstance = function(){
-
+  $scope.checkInstance = function() {
     // Loops through all system instances to find status of the model.instance
-    for(var i=0; i < $scope.system.instances.length; i++){
-        var instance = $scope.system.instances[i];
+    for (let i=0; i < $scope.system.instances.length; i++) {
+        let instance = $scope.system.instances[i];
 
         // Checks status to show banner if not running, hide banner if running
-        if(instance.name == $scope.model.instance_name){
-            if(instance.status != "RUNNING"){
+        if (instance.name == $scope.model.instance_name) {
+            if (instance.status != 'RUNNING') {
                 return true;
-            }
-            else{
+            } else {
                 return false;
             }
         }
@@ -89,7 +125,6 @@ export default function commandViewController($location, $scope, $state, $stateP
   };
 
   $scope.submitForm = function(form, model) {
-
     // Remove all the old alerts so they don't just stack up
     $scope.alerts.splice(0);
 
@@ -99,12 +134,12 @@ export default function commandViewController($location, $scope, $state, $stateP
     // This is gross, but tv4 does not handle arrays well and throws errors
     // where it shouldn't. I don't think it's possible to fix without a patch
     // to tv4 or ASF so for now just ignore the false positive.
-    var valid = true;
-    if(!form.$valid) {
+    let valid = true;
+    if (!form.$valid) {
       angular.forEach(form.$error, function(errorGroup, errorKey) {
-        if(errorKey !== 'schemaForm') {
+        if (errorKey !== 'schemaForm') {
           angular.forEach(errorGroup, function(error) {
-            if(errorKey !== 'tv4-0' || !Array.isArray(error.$modelValue)) {
+            if (errorKey !== 'tv4-0' || !Array.isArray(error.$modelValue)) {
               valid = false;
             }
           });
@@ -112,26 +147,26 @@ export default function commandViewController($location, $scope, $state, $stateP
       });
     }
 
-    if(valid) {
-      $scope.createRequest(model)
+    if (valid) {
+      $scope.createRequest(model);
     } else {
-      $scope.alerts.push("Looks like there was an error validating the request.");
+      $scope.alerts.push('Looks like there was an error validating the request.');
     }
   };
 
   $scope.createRequest = function(request) {
-    if (typeof(request) === "string") {
+    if (typeof(request) === 'string') {
       try {
-        request = JSON.parse(request)
-      } catch(err) {
+        request = JSON.parse(request);
+      } catch (err) {
         $scope.alerts.push(err);
-        return
+        return;
       }
     }
-    var newRequest = angular.copy(request);
+    let newRequest = angular.copy(request);
 
     newRequest['system'] = $scope.system['name'];
-    if($scope.system['display_name']) {
+    if ($scope.system['display_name']) {
       newRequest['metadata'] = {system_display_name: $scope.system['display_name']};
     }
 
@@ -144,7 +179,7 @@ export default function commandViewController($location, $scope, $state, $stateP
         $scope.createErrorMessage = response.data.message;
       }
     );
-  }
+  };
 
   $scope.reset = function(form, model, system, command) {
     $scope.alerts.splice(0);
@@ -167,14 +202,14 @@ export default function commandViewController($location, $scope, $state, $stateP
     UtilityService.formatJsonDisplay(_editor, false);
   };
 
-  $scope.toggleManualOverride = function(){
+  $scope.toggleManualOverride = function() {
     $scope.alerts.splice(0);
     $scope.manualOverride = !$scope.manualOverride;
     $scope.manualModel = $scope.jsonValues.model;
   };
 
-  var generateSF = function() {
-    var sf = SFBuilderService.build($scope.system, $scope.command.data);
+  let generateSF = function() {
+    let sf = SFBuilderService.build($scope.system, $scope.command.data);
     $scope.schema = sf['schema'];
     $scope.form = sf['form'];
 
@@ -191,21 +226,16 @@ export default function commandViewController($location, $scope, $state, $stateP
     $scope.jsonValues.command = JSON.stringify($scope.command.data, undefined, 2);
 
     // If this command has a custom template then we're done!
-    if($scope.command.data.template) {
-
+    if ($scope.command.data.template) {
       // This is necessary for things like scripts and forms
-      if($scope.config.allow_unsafe_templates) {
+      if ($scope.config.allowUnsafeTemplates) {
         $scope.template = $sce.trustAsHtml($scope.command.data.template);
-      }
-      else {
+      } else {
         $scope.template = $scope.command.data.template;
       }
 
       $scope.command.loaded = true;
-    }
-
-    // Otherwise request the system and then generate the schema-form
-    else {
+    } else {
       SystemService.getSystem(response.data.system.id, false).then(
         function(response) {
           $scope.system = response.data;
@@ -225,33 +255,37 @@ export default function commandViewController($location, $scope, $state, $stateP
   };
 
   $scope.$watch('model', function(val, old) {
-    if(val && val !== old) {
-      if($scope.system['display_name']) {
+    if (val && val !== old) {
+      if ($scope.system['display_name']) {
         val['system'] = $scope.system['display_name'];
       }
 
       try {
         $scope.jsonValues.model = angular.toJson(val, 2);
-      } catch(e) {
-        console.error("Error attempting to stringify the model");
+      } catch (e) {
+        console.error('Error attempting to stringify the model');
       }
     }
   }, true);
 
   // This process of stringify / parse will break the optional model
   // functionality. It's only useful in dev mode so only enable it then
-  if($scope.config.debug_mode === true) {
+  if ($scope.config.debugMode === true) {
     $scope.$watch('jsonValues', function(val, old) {
-      if(val && old) {
-        if(val.schema !== old.schema) {
+      if (val && old) {
+        if (val.schema !== old.schema) {
           try {
             $scope.schema = JSON.parse(val.schema);
-          } catch(e) { console.log("schema doesn't parse"); }
+          } catch (e) {
+            console.log('schema doesn\'t parse');
+          }
         }
-        if(val.form !== old.form) {
+        if (val.form !== old.form) {
           try {
             $scope.form = JSON.parse(val.form);
-          } catch(e) { console.log("form doesn't parse"); }
+          } catch (e) {
+            console.log('form doesn\'t parse');
+          }
         }
       }
     }, true);
@@ -261,7 +295,9 @@ export default function commandViewController($location, $scope, $state, $stateP
   $scope.$on('generateSF', generateSF);
 
   // Stop the loading animation after the schema form is done
-  $scope.$on('sf-render-finished', function(){$scope.command.loaded = true;});
+  $scope.$on('sf-render-finished', function() {
+    $scope.command.loaded = true;
+  });
 
   CommandService.getCommand($stateParams.command_id)
     .then($scope.successCallback, $scope.failureCallback);

--- a/brew_view/static/src/js/controllers/landing.js
+++ b/brew_view/static/src/js/controllers/landing.js
@@ -1,6 +1,29 @@
 
-landingController.$inject = ['$scope', '$rootScope', '$location', '$interval', 'SystemService', 'UtilityService'];
-export default function landingController($scope, $rootScope, $location, $interval, SystemService, UtilityService) {
+landingController.$inject = [
+  '$scope',
+  '$rootScope',
+  '$location',
+  '$interval',
+  'SystemService',
+  'UtilityService',
+];
+
+/**
+ * landingController - Controller for the landing page.
+ * @param  {$scope} $scope         Angular's $scope object.
+ * @param  {$rootScope} $rootScope Angular's $rootScope object.
+ * @param  {$location} $location   Angular's $location object.
+ * @param  {$interval} $interval   Angular's $interval object.
+ * @param  {Object} SystemService  Beer-Garden's sytem service.
+ * @param  {Object} UtilityService Beer-Garden's utility service.
+ */
+export default function landingController(
+  $scope,
+  $rootScope,
+  $location,
+  $interval,
+  SystemService,
+  UtilityService) {
   $scope.util = UtilityService;
 
   $scope.systems = {
@@ -11,36 +34,37 @@ export default function landingController($scope, $rootScope, $location, $interv
     status: null,
     errorMap: {
       'empty': {
-        'solutions' : [
+        'solutions': [
           {
-            problem     : 'Backend Down',
-            description : 'If the backend is down, there will be no systems to control',
-            resolution  : '<kbd>service bartender start</kbd>'
+            problem: 'Backend Down',
+            description: 'If the backend is down, there will be no systems to control',
+            resolution: '<kbd>service bartender start</kbd>',
           },
           {
-            problem     : 'Plugin Problems',
-            description : 'If Plugins attempted to start, but are failing to startup, then ' +
-                          'you\'ll have to contact the plugin maintainer. You can tell what\'s wrong '+
-                          'by their logs. Plugins are located at <code>$APP_HOME/plugins</code>',
-            resolution  : '<kbd>less $APP_HOME/log/my-plugin.log</kbd>'
+            problem: 'Plugin Problems',
+            description: 'If Plugins attempted to start, but are failing to startup, then ' +
+                         'you\'ll have to contact the plugin maintainer. You can tell what\'s ' +
+                         ' wrong by their logs. Plugins are located at ' +
+                         '<code>$APP_HOME/plugins</code>',
+            resolution: '<kbd>less $APP_HOME/log/my-plugin.log</kbd>',
           },
           {
-            problem     : 'Database Names Do Not Match',
-            description : 'It is possible that the backend is pointing to a Different Database than ' +
-                          'the Frontend. Check to make sure that the <code>DB_NAME</code> in both ' +
-                          'config files is the same',
-            resolution  : '<kbd>vim $APP_HOME/conf/bartender.json</kbd><br />' +
-                          '<kbd>vim $APP_HOME/conf/brew-view.json</kbd>'
+            problem: 'Database Names Do Not Match',
+            description: 'It is possible that the backend is pointing to a Different Database ' +
+                         'than the Frontend. Check to make sure that the <code>DB_NAME</code> ' +
+                         'in both config files is the same',
+            resolution: '<kbd>vim $APP_HOME/conf/bartender.json</kbd><br />' +
+                        '<kbd>vim $APP_HOME/conf/brew-view.json</kbd>',
           },
           {
-            problem     : 'There Are No Systems',
-            description : 'If no one has ever developed any plugins, then there will be no systems ' +
-                          'here. You\'ll need to build your own plugins.',
-            resolution  : 'Develop a Plugin'
-          }
-        ]
-      }
-    }
+            problem: 'There Are No Systems',
+            description: 'If no one has ever developed any plugins, then there will be no ' +
+                         'systems here. You\'ll need to build your own plugins.',
+            resolution: 'Develop a Plugin',
+          },
+        ],
+      },
+    },
   };
 
   $scope.successCallback = function(response) {
@@ -50,7 +74,7 @@ export default function landingController($scope, $rootScope, $location, $interv
     $scope.systems.error = false;
     $scope.systems.status = response.status;
     $scope.systems.errorMessage = '';
-  }
+  };
 
   $scope.failureCallback = function(response) {
     $scope.systems.data = [];
@@ -58,11 +82,11 @@ export default function landingController($scope, $rootScope, $location, $interv
     $scope.systems.error = true;
     $scope.systems.status = response.status;
     $scope.systems.errorMessage = response.data.message;
-  }
+  };
 
-  $scope.exploreSystem = function(system_id) {
-    $location.path('/systems/' + system_id);
-  }
+  $scope.exploreSystem = function(systemId) {
+    $location.path('/systems/' + systemId);
+  };
 
   SystemService.getSystems().then($scope.successCallback, $scope.failureCallback);
 };

--- a/brew_view/static/src/js/controllers/request_index.js
+++ b/brew_view/static/src/js/controllers/request_index.js
@@ -1,14 +1,33 @@
 import angular from 'angular';
 
-requestIndexController.$inject = ['$scope', 'DTOptionsBuilder', 'DTColumnBuilder', 'DTRendererService', 'RequestService'];
-export default function requestIndexController($scope, DTOptionsBuilder, DTColumnBuilder, DTRendererService, RequestService) {
+requestIndexController.$inject = [
+  '$scope',
+  'DTOptionsBuilder',
+  'DTColumnBuilder',
+  'DTRendererService',
+  'RequestService',
+];
+
+/**
+ * requestIndexController - Angular controller for viewing all requests.
+ * @param  {$scope} $scope            Angular's $scope object.
+ * @param  {Object} DTOptionsBuilder  Data-tables' options builder object.
+ * @param  {Object} DTColumnBuilder   Data-tables' column builder object.
+ * @param  {Object} DTRendererService Data-tables' rendering service.
+ * @param  {Object} RequestService    Beer-Garden Request Service.
+ */
+export default function requestIndexController(
+  $scope,
+  DTOptionsBuilder,
+  DTColumnBuilder,
+  DTRendererService,
+  RequestService) {
   $scope.requests = {};
   $scope.requests.errorMap = RequestService.errorMap;
 
   $scope.dtOptions = DTOptionsBuilder.newOptions()
     .withOption('autoWidth', false)
     .withOption('ajax', function(data, callback, settings) {
-
       // Need to also request ID for the href
       data.columns.push({'data': 'id'});
 
@@ -23,7 +42,7 @@ export default function requestIndexController($scope, DTOptionsBuilder, DTColum
             data: response.data,
             draw: response.headers('draw'),
             recordsFiltered: response.headers('recordsFiltered'),
-            recordsTotal: response.headers('recordsTotal')
+            recordsTotal: response.headers('recordsTotal'),
           });
         },
         function(response) {
@@ -35,24 +54,27 @@ export default function requestIndexController($scope, DTOptionsBuilder, DTColum
       );
     })
     .withLightColumnFilter({
-      0 : { html: 'input', type: 'text', attr: {class: 'form-inline form-control'} },
-      1 : { html: 'input', type: 'text', attr: {class: 'form-inline form-control'} },
-      2 : {
+      0: {html: 'input', type: 'text', attr: {class: 'form-inline form-control'}},
+      1: {html: 'input', type: 'text', attr: {class: 'form-inline form-control'}},
+      2: {
         html: 'select',
         type: 'text',
         cssClass: 'form-inline form-control',
         values: [
-          { value: '', label: '' },
-          { value: 'CREATED', label: 'CREATED' },
-          { value: 'RECEIVED', label: 'RECEIVED' },
-          { value: 'IN_PROGRESS', label: 'IN PROGRESS' },
-          { value: 'CANCELED', label: 'CANCELED' },
-          { value: 'SUCCESS', label: 'SUCCESS' },
-          { value: 'ERROR', label: 'ERROR' }
-        ]
+          {value: '', label: ''},
+          {value: 'CREATED', label: 'CREATED'},
+          {value: 'RECEIVED', label: 'RECEIVED'},
+          {value: 'IN_PROGRESS', label: 'IN PROGRESS'},
+          {value: 'CANCELED', label: 'CANCELED'},
+          {value: 'SUCCESS', label: 'SUCCESS'},
+          {value: 'ERROR', label: 'ERROR'},
+        ],
       },
-      3 : { html: 'range', type: 'text', attr: {class: 'form-inline form-control', style: 'width: 50%;'} },
-      4 : { html: 'input', type: 'text', attr: {class: 'form-inline form-control'} }
+      3: {
+        html: 'range', type: 'text',
+        attr: {class: 'form-inline form-control', style: 'width: 50%;'},
+      },
+      4: {html: 'input', type: 'text', attr: {class: 'form-inline form-control'}},
     })
     .withDataProp('data')
     .withOption('order', [3, 'desc'])
@@ -71,13 +93,13 @@ export default function requestIndexController($scope, DTOptionsBuilder, DTColum
       .newColumn('system')
       .withTitle('System')
       .renderWith(function(data, type, full) {
-        var systemName = data;
-        if(full['metadata'] && full['metadata']['system_display_name']) {
+        let systemName = data;
+        if (full['metadata'] && full['metadata']['system_display_name']) {
           systemName = full['metadata']['system_display_name'];
         }
 
-        if(angular.isDefined(full.instance_name) && full.instance_name !== null) {
-          return systemName + " [" + full.instance_name + "]";
+        if (angular.isDefined(full.instance_name) && full.instance_name !== null) {
+          return systemName + ' [' + full.instance_name + ']';
         } else {
           return systemName;
         }
@@ -98,20 +120,19 @@ export default function requestIndexController($scope, DTOptionsBuilder, DTColum
       .withTitle('Comment'),
     DTColumnBuilder
       .newColumn('metadata')
-      .notVisible()
+      .notVisible(),
   ];
 
   DTRendererService.registerPlugin({
     postRender: function(options, result) {
-
       // Insert our spinner thingy next to the search box
-      var spinner = $('<span>').addClass('spinner');
+      let spinner = $('<span>').addClass('spinner');
       $('.dataTables_filter label').prepend(spinner);
 
       // Register callback to show / hide spinner thingy
-      var processingDelay = null;
+      let processingDelay = null;
       $('.dataTable').on('processing.dt', function(e, settings, processing) {
-        if(!processing) {
+        if (!processing) {
           clearTimeout(processingDelay);
           spinner.css('visibility', 'hidden');
         } else {
@@ -120,6 +141,6 @@ export default function requestIndexController($scope, DTOptionsBuilder, DTColum
           }, 500);
         }
       });
-    }
+    },
   });
 };

--- a/brew_view/static/src/js/controllers/request_view.js
+++ b/brew_view/static/src/js/controllers/request_view.js
@@ -1,29 +1,59 @@
 
-requestViewController.$inject = ['$scope', '$state', '$stateParams', '$timeout', '$animate', 'RequestService', 'UtilityService', 'SystemService'];
-export default function requestViewController($scope, $state, $stateParams, $timeout, $animate, RequestService, UtilityService, SystemService) {
+requestViewController.$inject = [
+  '$scope',
+  '$state',
+  '$stateParams',
+  '$timeout',
+  '$animate',
+  'RequestService',
+  'UtilityService',
+  'SystemService',
+];
+
+/**
+ * requestViewController - Angular Controller for viewing an individual Request.
+ * @param  {$scope} $scope             Angular's $scope object.
+ * @param  {$state} $state             Angular's $state object.
+ * @param  {$stateParams} $stateParams Angular's $stateParams object.
+ * @param  {$timeout} $timeout         Angular's $timeout object.
+ * @param  {$animate} $animate         Angular's $animate object.
+ * @param  {Object} RequestService     Beer-Garden Request Service.
+ * @param  {Object} UtilityService     Beer-Garden's Utility Service.
+ * @param  {Object} SystemService      Beer-Garden's System Service.
+ */
+export default function requestViewController(
+  $scope,
+  $state,
+  $stateParams,
+  $timeout,
+  $animate,
+  RequestService,
+  UtilityService,
+  SystemService) {
   $scope.request = {};
   $scope.request.errorMap = RequestService.errorMap;
   $scope.service = RequestService;
   $scope.timeoutRequest;
   $scope.children = [];
-  $scope.children_collapsed = true;
+  $scope.childrenCollapsed = true;
 
-  $scope.raw_output = undefined;
-  $scope.formatted_output = "";
-  $scope.formatted_parameters = "";
-  $scope.formatted_available = false;
-  $scope.format_error_title = undefined;
-  $scope.format_error_msg = undefined;
-  $scope.show_formatted = false;
+  $scope.rawOutput = undefined;
+  $scope.formattedOutput = '';
+  $scope.formattedParameters = '';
+  $scope.formattedAvailable = false;
+  $scope.formatErrorTitle = undefined;
+  $scope.formatErrorMsg = undefined;
+  $scope.showFormatted = false;
 
-  $scope.instance_status = "";
-  $scope.status_descriptions = {
-    "CREATED"     : "The request has been validated by beer-garden and is on the queue awaiting processing.",
-    "RECEIVED"    : "Not used.",
-    "IN_PROGRESS" : "The request has been received by the plugin and is actively being processed.",
-    "CANCELED"    : "The request has been canceled and will not be processed.",
-    "SUCCESS"     : "The request has completed successfully",
-    "ERROR"       : "The request encountered an error during processing and will not be reprocessed."
+  $scope.instanceStatus = '';
+  $scope.statusDescriptions = {
+    'CREATED': 'The request has been validated by beer-garden and is on the queue ' +
+               'awaiting processing.',
+    'RECEIVED': 'Not used.',
+    'IN_PROGRESS': 'The request has been received by the plugin and is actively being processed.',
+    'CANCELED': 'The request has been canceled and will not be processed.',
+    'SUCCESS': 'The request has completed successfully',
+    'ERROR': 'The request encountered an error during processing and will not be reprocessed.',
   };
 
   $scope.loadPreview = function(_editor) {
@@ -31,11 +61,11 @@ export default function requestViewController($scope, $state, $stateParams, $tim
   };
 
   $scope.canRepeat = function(request) {
-    if(request.system === 'beer_garden') {
+    if (request.system === 'beer_garden') {
       return false;
     }
 
-    if(RequestService.complete_statuses.indexOf(request.status) != -1) {
+    if (RequestService.completeStatuses.indexOf(request.status) != -1) {
       return true;
     }
 
@@ -43,54 +73,50 @@ export default function requestViewController($scope, $state, $stateParams, $tim
   };
 
   $scope.formatOutput = function() {
-    $scope.formatted_output = "";
-    $scope.formatted_available = false;
-    $scope.show_formatted = false;
-    $scope.format_error_title = undefined;
-    $scope.format_error_msg = undefined;
+    $scope.formattedOutput = '';
+    $scope.formattedAvailable = false;
+    $scope.showFormatted = false;
+    $scope.formatErrorTitle = undefined;
+    $scope.formatErrorMsg = undefined;
 
-    var raw_output = $scope.request.data.output;
+    let rawOutput = $scope.request.data.output;
 
     try {
-      if(raw_output === undefined || raw_output == null) {
-        raw_output = 'null';
-      }
-      else if($scope.request.data.output_type == 'JSON') {
+      if (rawOutput === undefined || rawOutput == null) {
+        rawOutput = 'null';
+      } else if ($scope.request.data.output_type == 'JSON') {
         try {
-          var parsed_output = JSON.parse($scope.request.data.output);
-          raw_output = $scope.stringify(parsed_output);
+          const parsedOutput = JSON.parse($scope.request.data.output);
+          rawOutput = $scope.stringify(parsedOutput);
 
-          if($scope.countNodes($scope.formatted_output) < 1000) {
-            $scope.formatted_output = raw_output;
-            $scope.formatted_available = true;
-            $scope.show_formatted = true;
+          if ($scope.countNodes($scope.formattedOutput) < 1000) {
+            $scope.formattedOutput = rawOutput;
+            $scope.formattedAvailable = true;
+            $scope.showFormatted = true;
           } else {
-            $scope.format_error_title = "Output is too large for collapsible view";
-            $scope.format_error_msg = "This output is valid JSON, but it's so big that displaying it in the" +
-            " collapsible viewer would crash the page."
+            $scope.formatErrorTitle = 'Output is too large for collapsible view';
+            $scope.formatErrorMsg = 'This output is valid JSON, but it\'s so big that ' +
+                                      'displaying it in the collapsible viewer would crash the ' +
+                                      'page.';
           }
+        } catch (err) {
+          $scope.formatErrorTitle = 'This JSON didn\'t parse correctly';
+          $scope.formatErrorMsg = 'beer-garden was expecting this output to be JSON but it ' +
+                                    'doesn\'t look like JSON. If this is happening often please ' +
+                                    'let the plugin developer know.';
         }
-        catch(err) {
-          $scope.format_error_title = "This JSON didn't parse correctly";
-          $scope.format_error_msg = "beer-garden was expecting this output to be JSON but it doesn't look like JSON." +
-            " If this is happening often please let the plugin developer know.";
-        }
-      }
-      // For version 1 we're assuming that STRING types are really JSON. But they don't get the special view
-      else if($scope.request.data.output_type == 'STRING') {
+      } else if ($scope.request.data.output_type == 'STRING') {
         try {
-          raw_output = $scope.stringify(JSON.parse($scope.request.data.output));
-        }
-        catch(err) { }
+          rawOutput = $scope.stringify(JSON.parse($scope.request.data.output));
+        } catch (err) { }
       }
-    }
-    finally {
-      $scope.raw_output = raw_output;
+    } finally {
+      $scope.rawOutput = rawOutput;
     }
   };
 
   $scope.formatDate = function(timestamp) {
-    if(timestamp) {
+    if (timestamp) {
       return new Date(timestamp).toUTCString();
     }
   };
@@ -103,26 +129,22 @@ export default function requestViewController($scope, $state, $stateParams, $tim
     $scope.request.errorMessage = '';
 
     $scope.formatOutput();
-    $scope.formatted_parameters = $scope.stringify($scope.request.data.parameters);
+    $scope.formattedParameters = $scope.stringify($scope.request.data.parameters);
 
     // If request is not yet successful
     // We need to find system attached to request
     // And find out if the status of that instance is up
-    if(RequestService.complete_statuses.indexOf(response.data.status) == -1){
-
+    if (RequestService.completeStatuses.indexOf(response.data.status) == -1) {
       // Get promise to get id of system associated with the response
-      SystemService.getSystemID(response.data).then(function(systemId){
-
+      SystemService.getSystemID(response.data).then(function(systemId) {
         // Using the system ID we can then get the system and instances
-        SystemService.getSystem(systemId, false).then(function(systemObj){
-
-          for(var i = 0; i < systemObj.data.instances.length; i++){
-
-            if(systemObj.data.instances[i].name == response.data.instance_name){
-
-              // It's possible the instance comes back up before we get here so we don't want to show it is running yet
-              // So in the html we need to put an ngif against instance_status == 'RUNNING'
-              $scope.instance_status = systemObj.data.instances[i].status;
+        SystemService.getSystem(systemId, false).then(function(systemObj) {
+          for (const i = 0; i < systemObj.data.instances.length; i++) {
+            if (systemObj.data.instances[i].name == response.data.instance_name) {
+              // It's possible the instance comes back up before we get here so we don't want
+              // to show it is running yet so in the html we need to put an ngif against
+              // instanceStatus == 'RUNNING'
+              $scope.instanceStatus = systemObj.data.instances[i].status;
             }
           }
         });
@@ -130,12 +152,12 @@ export default function requestViewController($scope, $state, $stateParams, $tim
     }
 
     // If the children view is expanded we have to do a little update
-    if(!$scope.children_collapsed) {
+    if (!$scope.childrenCollapsed) {
       $scope.children = response.data.children;
     }
 
     // If request isn't done then we need to keep checking
-    if(RequestService.complete_statuses.indexOf(response.data.status) == -1) {
+    if (RequestService.completeStatuses.indexOf(response.data.status) == -1) {
       $scope.timeoutRequest = $timeout(function() {
         RequestService.getRequest($stateParams.request_id)
           .then($scope.successCallback, $scope.failureCallback);
@@ -151,40 +173,40 @@ export default function requestViewController($scope, $state, $stateParams, $tim
     $scope.request.error = true;
     $scope.request.status = response.status;
     $scope.request.errorMessage = response.data.message;
-    $scope.raw_output = undefined;
-    $scope.formatted_output = undefined;
-    $scope.formatted_available = false;
-    $scope.show_formatted = false;
-    $scope.format_error_title = undefined;
-    $scope.format_error_msg = undefined;
+    $scope.rawOutput = undefined;
+    $scope.formattedOutput = undefined;
+    $scope.formattedAvailable = false;
+    $scope.showFormatted = false;
+    $scope.formatErrorTitle = undefined;
+    $scope.formatErrorMsg = undefined;
   };
 
   $scope.redoRequest = function(request) {
     RequestService.getCommandId(request).then(
       function(id) {
-        if(id !== null) {
-          var newRequest = {
+        if (id !== null) {
+          const newRequest = {
             system: request.system,
             system_version: request.system_version,
             command: request.command,
             instance_name: request.instance_name,
             comment: request.comment || '',
-            parameters: request.parameters
+            parameters: request.parameters,
           };
 
-          $state.go('command', { command_id: id, request: newRequest });
+          $state.go('command', {command_id: id, request: newRequest});
         } else {
-          alert("We're sorry, but this command no longer seems to exist.");
+          alert('We\'re sorry, but this command no longer seems to exist.');
         }
       },
       function(data, status, headers, config) {
-        alert("We're sorry, but a server error occurred trying to redirect you.");
+        alert('We\'re sorry, but a server error occurred trying to redirect you.');
       }
     );
   };
 
   $scope.$on('$destroy', function() {
-    if($scope.timeoutRequest) {
+    if ($scope.timeoutRequest) {
       $timeout.cancel($scope.timeoutRequest);
     }
   });
@@ -194,19 +216,20 @@ export default function requestViewController($scope, $state, $stateParams, $tim
   };
 
   $scope.hasChildren = function(request) {
-    return request.children !== undefined && request.children !== null && request.children.length > 0;
+    return request.children !== undefined &&
+           request.children !== null &&
+           request.children.length > 0;
   };
 
   $scope.toggleChildren = function() {
-
     $animate.enabled($('#requestTable'), true);
     $scope.disableAnimation = $timeout(function() {
       $animate.enabled($('#requestTable'), false);
     }, 300);
 
-    $scope.children_collapsed = !$scope.children_collapsed;
+    $scope.childrenCollapsed = !$scope.childrenCollapsed;
 
-    if($scope.children_collapsed) {
+    if ($scope.childrenCollapsed) {
       $scope.children = [];
     } else {
       $scope.children = $scope.request.data.children;
@@ -214,14 +237,14 @@ export default function requestViewController($scope, $state, $stateParams, $tim
   };
 
   $scope.showColumn = function(property) {
-    if($scope.request.data[property] !== undefined && $scope.request.data[property] !== null) {
+    if ($scope.request.data[property] !== undefined && $scope.request.data[property] !== null) {
       return true;
     }
 
-    var show = false;
-    if($scope.hasChildren($scope.request.data)) {
+    let show = false;
+    if ($scope.hasChildren($scope.request.data)) {
       $scope.request.data.children.forEach(function(child) {
-        if(child[property] !== undefined && child[property] !== null) {
+        if (child[property] !== undefined && child[property] !== null) {
           show = true;
         }
       });
@@ -231,8 +254,7 @@ export default function requestViewController($scope, $state, $stateParams, $tim
   };
 
   $scope.getParentTree = function(request) {
-
-    if(!$scope.hasParent(request)) {
+    if (!$scope.hasParent(request)) {
       return [request];
     } else {
       return $scope.getParentTree(request.parent).concat(request);
@@ -245,13 +267,13 @@ export default function requestViewController($scope, $state, $stateParams, $tim
 
   $scope.countNodes = function(obj) {
     // Arrays have type object too
-    if(typeof obj != "object") {
+    if (typeof obj != 'object') {
       return 1;
     }
 
-    var total = 1;
-    for(var key in obj) {
-      total += $scope.countNodes(obj[key]);
+    let total = 1;
+    for (const key of Object.keys(obj)) {
+      total += $scope.countNodes(object[key]);
     }
     return total;
   };
@@ -260,6 +282,11 @@ export default function requestViewController($scope, $state, $stateParams, $tim
     .then($scope.successCallback, $scope.failureCallback);
 };
 
+
+/**
+ * slideAnimation - Animation for sliding children.
+ * @return {Object} with enter/leave functions.
+ */
 export function slideAnimation() {
   return {
     enter: function(element, doneFn) {
@@ -274,6 +301,6 @@ export function slideAnimation() {
       $(element).children('td').children('div').slideUp(250, function() {
         doneFn();
       });
-    }
-  }
+    },
+  };
 };

--- a/brew_view/static/src/js/controllers/request_view.js
+++ b/brew_view/static/src/js/controllers/request_view.js
@@ -86,7 +86,7 @@ export default function requestViewController(
         rawOutput = 'null';
       } else if ($scope.request.data.output_type == 'JSON') {
         try {
-          const parsedOutput = JSON.parse($scope.request.data.output);
+          let parsedOutput = JSON.parse($scope.request.data.output);
           rawOutput = $scope.stringify(parsedOutput);
 
           if ($scope.countNodes($scope.formattedOutput) < 1000) {
@@ -139,7 +139,7 @@ export default function requestViewController(
       SystemService.getSystemID(response.data).then(function(systemId) {
         // Using the system ID we can then get the system and instances
         SystemService.getSystem(systemId, false).then(function(systemObj) {
-          for (const i = 0; i < systemObj.data.instances.length; i++) {
+          for (let i = 0; i < systemObj.data.instances.length; i++) {
             if (systemObj.data.instances[i].name == response.data.instance_name) {
               // It's possible the instance comes back up before we get here so we don't want
               // to show it is running yet so in the html we need to put an ngif against

--- a/brew_view/static/src/js/controllers/system_view.js
+++ b/brew_view/static/src/js/controllers/system_view.js
@@ -1,7 +1,33 @@
 import angular from 'angular';
 
-systemViewController.$inject = ['$scope', '$stateParams', '$interval', 'SystemService', 'CommandService', 'UtilityService', 'DTOptionsBuilder'];
-export default function systemViewController($scope, $stateParams, $interval, SystemService, CommandService, UtilityService, DTOptionsBuilder) {
+systemViewController.$inject = [
+  '$scope',
+  '$stateParams',
+  '$interval',
+  'SystemService',
+  'CommandService',
+  'UtilityService',
+  'DTOptionsBuilder',
+];
+
+/**
+ * systemViewController - Angular Controller for viewing a single system.
+ * @param  {$scope} $scope             Angular's $scope object.
+ * @param  {$stateParams} $stateParams Angular's $stateParams object.
+ * @param  {$interval} $interval       Angular's $interval object.
+ * @param  {Object} SystemService      Beer-Garden System Service.
+ * @param  {Object} CommandService     Beer-Garden Command Service.
+ * @param  {Object} UtilityService     Beer-Garden Utility Service.
+ * @param  {Object} DTOptionsBuilder   Object for building Data-Tables objects.
+ */
+export default function systemViewController(
+  $scope,
+  $stateParams,
+  $interval,
+  SystemService,
+  CommandService,
+  UtilityService,
+  DTOptionsBuilder) {
   $scope.util = UtilityService;
 
   $scope.system = {
@@ -12,23 +38,25 @@ export default function systemViewController($scope, $stateParams, $interval, Sy
     forceReload: false,
     status: null,
     errorMap: {
-      'empty' : {
-        'solutions' : [
+      'empty': {
+        'solutions': [
           {
-            problem     : 'ID is incorrect',
-            description : 'The Backend has restarted and the ID changed of the system you were looking at',
-            resolution  : 'Click the ' + $scope.config.application_name + ' logo at the top left and refresh the page'
+            problem: 'ID is incorrect',
+            description: 'The Backend has restarted and the ID changed of the system you ' +
+                         'were looking at',
+            resolution: 'Click the ' + $scope.config.applicationName + ' logo at the top ' +
+                        'left and refresh the page',
           },
           {
-            problem     : 'The Plugin Stopped',
-            description : 'The plugin could have been stopped. You should probably contact the plugin ' +
-                          'maintainer. You should be able to tell what\'s wrong by their logs. Plugins ' +
-                          'are located at <code>$APP_HOME/plugins</code>',
-            resolution  : '<kbd>less $APP_HOME/log/my-plugin.log</kbd>'
-          }
-        ]
-      }
-    }
+            problem: 'The Plugin Stopped',
+            description: 'The plugin could have been stopped. You should probably contact the ' +
+                         'plugin maintainer. You should be able to tell what\'s wrong by their ' +
+                         'logs. Plugins are located at <code>$APP_HOME/plugins</code>',
+            resolution: '<kbd>less $APP_HOME/log/my-plugin.log</kbd>',
+          },
+        ],
+      },
+    },
   };
 
   $scope.dtOptions = DTOptionsBuilder.newOptions()
@@ -42,7 +70,7 @@ export default function systemViewController($scope, $stateParams, $interval, Sy
     $scope.system.error = false;
     $scope.system.status = response.status;
     $scope.system.errorMessage = '';
-  }
+  };
 
   $scope.failureCallback = function(response) {
     $scope.system.data = {};
@@ -50,21 +78,23 @@ export default function systemViewController($scope, $stateParams, $interval, Sy
     $scope.system.error = true;
     $scope.system.status = response.status;
     $scope.system.errorMessage = data.message;
-  }
+  };
 
   // Register a function that polls if the system is in a transition status
-  var status_update = $interval(function() {
-    if(['STOPPING', 'STARTING'].indexOf($scope.system.data.status) != -1) {
-      SystemService.getSystem($scope.system.data.id, false, function(data, status, headers, config) {
-        $scope.system.data.status = data.status;
+  let statusUpdate = $interval(function() {
+    if (['STOPPING', 'STARTING'].indexOf($scope.system.data.status) != -1) {
+      SystemService.getSystem(
+        $scope.system.data.id, false,
+        function(data, status, headers, config) {
+          $scope.system.data.status = data.status;
       });
     }
   }, 1000);
 
   $scope.$on('$destroy', function() {
-    if(angular.isDefined(status_update)) {
-      $interval.cancel(status_update);
-      status_update = undefined;
+    if (angular.isDefined(statusUpdate)) {
+      $interval.cancel(statusUpdate);
+      statusUpdate = undefined;
     }
   });
 

--- a/brew_view/static/src/js/directives/dataTables.lcf.datetimepicker.fr.js
+++ b/brew_view/static/src/js/directives/dataTables.lcf.datetimepicker.fr.js
@@ -1,12 +1,15 @@
-/*!
- * Wrapper module for eonasdan-bootstrap-datetimepicker
+
+/**
+ * function - Wrapper module for eonasdan-bootstrap-datetimepicker
  *
  * Based on dataTables.lcf.datetimepicker.fr.js:
  * @author Thomas <thansen@solire.fr>
  * @license CC BY-NC 4.0 http://creativecommons.org/licenses/by-nc/4.0/
+ * @param  {window} window     JS Window Object.
+ * @param  {document} document JS Location Object.
  */
 (function(window, document) {
-  var factory = function($, ColumnFilter) {
+  let factory = function($, ColumnFilter) {
     'use strict';
 
     ColumnFilter.filter.rangeBase = $.extend(true, {}, ColumnFilter.filter.range);
@@ -16,13 +19,13 @@
       ColumnFilter.filter.rangeBase,
       {
         separator: '~',
-        dom: function (th) {
-          var self = this;
+        dom: function(th) {
+          let self = this;
 
           // Picket widgets need to be inside a relative-positioned element
           th.css('position', 'relative');
 
-          var pickerElement = $('<input>', { type: self.options.type || 'text' });
+          let pickerElement = $('<input>', {type: self.options.type || 'text'});
 
           $.each(self.options.attr, function(key, value) {
             pickerElement.attr(key, value);
@@ -31,11 +34,11 @@
           self.startPickerElem = pickerElement.clone().attr('placeholder', 'start');
           self.endPickerElem = pickerElement.clone().attr('placeholder', 'end');
 
-          var pickerOptions = {
+          let pickerOptions = {
             format: 'YYYY-MM-DD',
             showClear: true,
             showTodayButton: true,
-            useCurrent: false
+            useCurrent: false,
           };
 
           self.elements = self.startPickerElem.datetimepicker(pickerOptions)
@@ -44,27 +47,41 @@
 
           return self.elements;
         },
-        bindEvents: function(){
-          var self = this;
+        bindEvents: function() {
+          const self = this;
 
-          self.startPickerElem.on('dp.change', function() { self.search(); });
-          self.endPickerElem.on('dp.change', function() { self.search(); });
+          self.startPickerElem.on('dp.change', function() {
+            self.search();
+          });
+          self.endPickerElem.on('dp.change', function() {
+            self.search();
+          });
         },
-        request: function(){
-          var self = this;
+        request: function() {
+          const self = this;
 
-          return [self.startPickerElem.val(), self.endPickerElem.val()].join(self.options.separator);
-        }
+          return [
+            self.startPickerElem.val(), self.endPickerElem.val(),
+          ].join(self.options.separator);
+        },
       }
     );
   };
 
   // Define as an AMD module if possible
   if (typeof define === 'function' && define.amd) {
-    define(['jquery', 'datatables-light-columnfilter', 'eonasdan-bootstrap-datetimepicker'], factory);
+    define([
+      'jquery',
+      'datatables-light-columnfilter',
+      'eonasdan-bootstrap-datetimepicker',
+    ], factory);
   } else if (typeof exports === 'object') {
     // Node/CommonJS
-    factory(require('jquery'), require('datatables-light-columnfilter'), require('eonasdan-bootstrap-datetimepicker'));
+    factory(
+      require('jquery'),
+      require('datatables-light-columnfilter'),
+      require('eonasdan-bootstrap-datetimepicker')
+    );
   } else if (jQuery) {
     // Otherwise simply initialise as normal, stopping multiple evaluation
     factory(jQuery, jQuery.fn.dataTable.ColumnFilter);

--- a/brew_view/static/src/js/directives/empty.js
+++ b/brew_view/static/src/js/directives/empty.js
@@ -1,12 +1,16 @@
 import template from '../../templates/empty.html';
 
+/**
+ * emptyDirective - Directive for rendering empty 200's.
+ * @return {Object}  Angular Directive
+ */
 export default function emptyDirective() {
   return {
     restrict: 'E',
     scope: {
       loader: '=',
-      label:  '@'
+      label: '@',
     },
-    template: template
+    template: template,
   };
 };

--- a/brew_view/static/src/js/directives/loading.js
+++ b/brew_view/static/src/js/directives/loading.js
@@ -2,25 +2,30 @@ import angular from 'angular';
 import template from '../../templates/loading.html';
 
 loadingDirective.$inject = ['$timeout'];
+
+/**
+ * loadingDirective - Directive for rendering a loading spinner.
+ * @param  {$timeout} $timeout Angular's $timeout Object.
+ * @return {Object}            Angular Directive.
+ */
 export default function loadingDirective($timeout) {
   return {
     restrict: 'E',
     scope: {
-      loader: "=",
-      delay: "@?"
+      loader: '=',
+      delay: '@?',
     },
     template: template,
     link: function(scope, element, attrs) {
-      var delay = angular.isDefined(scope.delay) ? parseFloat(scope.delay) : 0.25;
+      const delay = angular.isDefined(scope.delay) ? parseFloat(scope.delay) : 0.25;
 
-      if(!delay) {
+      if (!delay) {
         scope.showSpin = true;
-      }
-      else {
+      } else {
         $timeout(function() {
           scope.showSpin = true;
         }, delay * 1000);
       }
-    }
+    },
   };
 };

--- a/brew_view/static/src/js/directives/server_error.js
+++ b/brew_view/static/src/js/directives/server_error.js
@@ -1,11 +1,16 @@
 import template from '../../templates/server_error.html';
 
+
+/**
+ * serverErrorDirective - Directive for rendering a server error.
+ * @return {Object} Directive for Angular.
+ */
 export default function serverErrorDirective() {
   return {
     restrict: 'E',
     scope: {
-      loader: '='
+      loader: '=',
     },
-    template: template
+    template: template,
   };
 };

--- a/brew_view/static/src/js/directives/system_status.js
+++ b/brew_view/static/src/js/directives/system_status.js
@@ -1,15 +1,19 @@
 import template from '../../templates/system_status.html';
 
+/**
+ * systemStatusDirective - Directive for rendering system status.
+ * @return {Object}  Directive for Angular.
+ */
 export default function systemStatusDirective() {
   return {
     restrict: 'E',
     scope: {
-      status: '=target'
+      status: '=target',
     },
     template: template,
     link: function(scope, element, attrs) {
       scope.$watch('status', function() {
-        switch(scope.status) {
+        switch (scope.status) {
           case 'RUNNING':
             scope.labelClass = 'label-success';
             break;
@@ -30,6 +34,6 @@ export default function systemStatusDirective() {
             break;
         }
       });
-    }
+    },
   };
 };

--- a/brew_view/static/src/js/run.js
+++ b/brew_view/static/src/js/run.js
@@ -1,5 +1,22 @@
 
-appRun.$inject = ['$rootScope', '$state', '$stateParams', '$cookies', 'UtilityService', 'SystemService'];
+appRun.$inject = [
+  '$rootScope',
+  '$state',
+  '$stateParams',
+  '$cookies',
+  'UtilityService',
+  'SystemService',
+];
+
+/**
+ * appRun - Runs the front-end application.
+ * @param  {$rootScope} $rootScope         Angular's $rootScope object.
+ * @param  {$state} $state                 Angular's $state object.
+ * @param  {$stateParams} $stateParams     Angular's $stateParams object.
+ * @param  {$cookies} $cookies             Angular's $cookies object.
+ * @param  {UtilityService} UtilityService UtilityService for getting configuration/icons.
+ * @param  {SystemService} SystemService   SystemService for getting all System information.
+ */
 export function appRun($rootScope, $state, $stateParams, $cookies, UtilityService, SystemService) {
   $rootScope.$state = $state;
   $rootScope.$stateParams = $stateParams;
@@ -10,7 +27,8 @@ export function appRun($rootScope, $state, $stateParams, $cookies, UtilityServic
   // Set a default config and update it with config from the server
   $rootScope.config = {};
   UtilityService.getConfig().then(function(response) {
-    angular.extend($rootScope.config, response.data);
+    let camelData = UtilityService.camelCaseKeys(response.data);
+    angular.extend($rootScope.config, camelData);
     $rootScope.$broadcast('configLoaded');
   });
 
@@ -21,22 +39,27 @@ export function appRun($rootScope, $state, $stateParams, $cookies, UtilityServic
   });
 
   $rootScope.themes = {
-    "default": false,
-    "slate": false
+    'default': false,
+    'slate': false,
   };
 
-  $rootScope.changeTheme = function(theme){
+  $rootScope.changeTheme = function(theme) {
     $cookies.put('currentTheme', theme);
-    for (var key in $rootScope.themes) {
+    for (const key of Object.keys($rootScope.themes)) {
       $rootScope.themes[key] = (key == theme);
-    }
+    };
   };
 
   // Uses cookies to get the current theme
   $rootScope.changeTheme($cookies.get('currentTheme') || 'default');
 };
 
+
 dtLoadingTemplate.$inject = ['DTDefaultOptions'];
+/**
+ * dtLoadingTemplate - Loading Template for datatabales
+ * @param  {Object} DTDefaultOptions Data-tables default options.
+ */
 export function dtLoadingTemplate(DTDefaultOptions) {
   DTDefaultOptions.setLoadingTemplate('<div class="row"><loading loader="queues"></loading></div>');
 };

--- a/brew_view/static/src/js/services/admin_service.js
+++ b/brew_view/static/src/js/services/admin_service.js
@@ -1,9 +1,15 @@
 
 adminService.$inject = ['$http'];
+
+/**
+ * adminService - Service for interacting with the admin API.
+ * @param  {$http} $http Angular's $http Object.
+ * @return {Object}      Service for interacting with the admin API.
+ */
 export default function adminService($http) {
   return {
     rescan: function() {
       return $http.patch('api/v1/admin/', {operations: [{operation: 'rescan'}]});
-    }
-  }
+    },
+  };
 };

--- a/brew_view/static/src/js/services/command_service.js
+++ b/brew_view/static/src/js/services/command_service.js
@@ -1,38 +1,46 @@
 
 commandService.$inject = ['$http', '$rootScope', 'SystemService'];
+
+/**
+ * commandService - Service for interacting with the command API.
+ * @param  {$http} $http           Angular's $http Object.
+ * @param  {$rootScope} $rootScope Angular's $rootScope Object.
+ * @param  {Object} SystemService  Service for interacting with the system API.
+ * @return {Object}               Service for interacting with the command API.
+ */
 export default function commandService($http, $rootScope, SystemService) {
-  var CommandService = {};
+  let CommandService = {};
 
   CommandService.getSystemName = function(command) {
-    var system = CommandService.findSystem(command);
+    const system = CommandService.findSystem(command);
     return system.display_name || system.name;
-  }
+  },
 
   CommandService.findSystem = function(command) {
-    var system_id = command.system.id;
-    for( var index in $rootScope.systems ) {
-      if ( system_id == $rootScope.systems[index].id ) {
+    const systemId = command.system.id;
+    for ( let index in $rootScope.systems ) {
+      if ( systemId == $rootScope.systems[index].id ) {
         return $rootScope.systems[index];
       }
     }
-  }
+  },
 
   CommandService.getCommands = function() {
     return $http.get('api/v1/commands');
-  }
+  },
 
   CommandService.getCommand = function(id) {
     return $http.get('api/v1/commands/' + id);
-  }
+  },
 
   CommandService.comparison = function(a, b) {
-    var aSystem = CommandService.getSystemName(a);
-    var bSystem = CommandService.getSystemName(b);
+    const aSystem = CommandService.getSystemName(a);
+    const bSystem = CommandService.getSystemName(b);
 
-    if(aSystem < bSystem) return -1;
-    if(aSystem > bSystem) return 1;
-    if(a.name < b.name) return -1;
-    if(a.name > b.name) return 1;
+    if (aSystem < bSystem) return -1;
+    if (aSystem > bSystem) return 1;
+    if (a.name < b.name) return -1;
+    if (a.name > b.name) return 1;
     return 0;
   };
 

--- a/brew_view/static/src/js/services/instance_service.js
+++ b/brew_view/static/src/js/services/instance_service.js
@@ -1,5 +1,11 @@
 
 instanceService.$inject = ['$http'];
+
+/**
+ * instanceService - Service for interacting with the instance API.
+ * @param  {$http} $http Angular's $http object.
+ * @return {Object}      Service for interacting with the instance API.
+ */
 export default function instanceService($http) {
   return {
     startInstance: function(instance) {
@@ -11,6 +17,6 @@ export default function instanceService($http) {
       return $http.patch('api/v1/instances/' + instance.id,
         {operations: [{operation: 'replace', path: '/status', value: 'stopping'}]}
       );
-    }
+    },
   };
 };

--- a/brew_view/static/src/js/services/queue_service.js
+++ b/brew_view/static/src/js/services/queue_service.js
@@ -1,38 +1,45 @@
 
 queueService.$inject = ['$http'];
+
+/**
+ * queueService - Service for intereacting with the QueueAPI
+ * @param  {$http} $http Angular's $http Object.
+ * @return {Object}      Service for intereacting with the QueueAPI
+ */
 export default function queueService($http) {
   return {
     errorMap: {
       'empty': {
-        'solutions' : [
+        'solutions': [
           {
-            problem     : 'Backend Down',
-            description : 'If the backend is down, there will be no queues to control',
-            resolution  : '<kbd>service bartender start</kbd>'
+            problem: 'Backend Down',
+            description: 'If the backend is down, there will be no queues to control',
+            resolution: '<kbd>service bartender start</kbd>',
           },
           {
-            problem     : 'Plugin Problems',
-            description : 'If Plugins attempted to start, but are failing to startup, then' +
+            problem: 'Plugin Problems',
+            description: 'If Plugins attempted to start, but are failing to startup, then' +
                           'you\'ll have to contact the plugin maintainer. You can tell what\'s '+
-                          'wrong by their logs. Plugins are located at <code>$APP_HOME/plugins</code>',
-            resolution  : '<kbd>less $APP_HOME/log/my-plugin.log</kbd>'
+                          'wrong by their logs. Plugins are located at ' +
+                          '<code>$APP_HOME/plugins</code>',
+            resolution: '<kbd>less $APP_HOME/log/my-plugin.log</kbd>',
           },
           {
-            problem     : 'Database Names Do Not Match',
-            description : 'It is possible that the backend is pointing to a Different Database than ' +
-                          'the Frontend. Check to make sure that the <code>DB_NAME</code> in both ' +
-                          'config files is the same',
-            resolution  : '<kbd>vim $APP_HOME/conf/bartender.json</kbd><br />' +
-                          '<kbd>vim $APP_HOME/conf/brew-view.json</kbd>'
+            problem: 'Database Names Do Not Match',
+            description: 'It is possible that the backend is pointing to a Different Database ' +
+                         'than the Frontend. Check to make sure that the <code>DB_NAME</code> ' +
+                         'in both config files is the same',
+            resolution: '<kbd>vim $APP_HOME/conf/bartender.json</kbd><br />' +
+                          '<kbd>vim $APP_HOME/conf/brew-view.json</kbd>',
           },
           {
-            problem     : 'There Are No Queues',
-            description : 'If no one has ever developed any plugins, then there will be no queues' +
-                          'here. You\'ll need to build your own plugins.',
-            resolution  : 'Develop a Plugin'
-          }
-        ]
-      }
+            problem: 'There Are No Queues',
+            description: 'If no one has ever developed any plugins, then there will be no queues' +
+                         'here. You\'ll need to build your own plugins.',
+            resolution: 'Develop a Plugin',
+          },
+        ],
+      },
     },
 
     getQueues: function(success, error) {
@@ -45,6 +52,6 @@ export default function queueService($http) {
 
     clearQueue: function(name) {
       return $http.delete('api/v1/queues/' + name);
-    }
+    },
   };
 };

--- a/brew_view/static/src/js/services/request_service.js
+++ b/brew_view/static/src/js/services/request_service.js
@@ -1,26 +1,34 @@
 
 requestService.$inject = ['$q', '$http', '$timeout'];
+
+/**
+ * requestService - Service for accessing the Request API.
+ * @param  {$q} $q             Angular's $q object.
+ * @param  {$http} $http       Angular's $http object.
+ * @param  {$timeout} $timeout Angular's $timeout object.
+ * @return {Object}            An Object for interacting with the Request API.
+ */
 export default function requestService($q, $http, $timeout) {
-  var RequestService = {};
+  let RequestService = {};
 
   RequestService.complete_statuses = ['SUCCESS', 'ERROR', 'CANCELED'];
 
   RequestService.errorMap = {
     'empty': {
-      'solutions' : [
+      'solutions': [
         {
           problem: 'Request was removed',
           description: 'INFO-type requests are removed after several minutes',
-          resolution:  'Go back to the list of all requests'
+          resolution: 'Go back to the list of all requests',
         },
         {
           problem: 'ID is Incorrect',
           description: 'The ID Specified is incorrect. It does not refer to a valid request',
-          resolution:  'Go back to the list of all requests'
-        }
-      ]
-    }
-  }
+          resolution: 'Go back to the list of all requests',
+        },
+      ],
+    },
+  };
 
   RequestService.getRequests = function(data) {
     return $http.get('api/v1/requests', {params: data});
@@ -35,16 +43,15 @@ export default function requestService($q, $http, $timeout) {
   };
 
   RequestService.createRequestWait = function(request) {
-    var deferred = $q.defer();
-    var timeoutRequest;
+    let deferred = $q.defer();
 
     // Create our checker function and immediately invoke it
-    var checkForCompletion = function(id) {
+    const checkForCompletion = function(id) {
       RequestService.getRequest(id).then(
         function(response) {
-          if(RequestService.complete_statuses.indexOf(response.data.status) == -1) {
+          if (RequestService.complete_statuses.indexOf(response.data.status) == -1) {
             // If request isn't done then we need to keep checking
-            timeoutRequest = $timeout(function() {
+            $timeout(function() {
               checkForCompletion(id);
             }, 500);
           } else {
@@ -65,20 +72,22 @@ export default function requestService($q, $http, $timeout) {
   };
 
   RequestService.getCommandId = function(request) {
-    var promise = $http.get('api/v1/systems', {params: {name: request.system, include_commands: true} })
-      .then(function(response) {
-        var commandId = null;
-        if(response.data.length > 0) {
-          for(var i = 0; i < response.data[0].commands.length; i++) {
-            var command = response.data[0].commands[i]
-            if(command.name === request.command) {
-              commandId = command.id;
-              break;
-            }
+    const promise = $http.get(
+      'api/v1/systems', {params: {name: request.system, include_commands: true}}
+    )
+    .then(function(response) {
+      let commandId = null;
+      if (response.data.length > 0) {
+        for (let i = 0; i < response.data[0].commands.length; i++) {
+          let command = response.data[0].commands[i];
+          if (command.name === request.command) {
+            commandId = command.id;
+            break;
           }
         }
-        return commandId;
-      });
+      }
+      return commandId;
+    });
     return promise;
   };
 

--- a/brew_view/static/src/js/services/request_service.js
+++ b/brew_view/static/src/js/services/request_service.js
@@ -11,7 +11,7 @@ requestService.$inject = ['$q', '$http', '$timeout'];
 export default function requestService($q, $http, $timeout) {
   let RequestService = {};
 
-  RequestService.complete_statuses = ['SUCCESS', 'ERROR', 'CANCELED'];
+  RequestService.completeStatuses = ['SUCCESS', 'ERROR', 'CANCELED'];
 
   RequestService.errorMap = {
     'empty': {
@@ -49,7 +49,7 @@ export default function requestService($q, $http, $timeout) {
     const checkForCompletion = function(id) {
       RequestService.getRequest(id).then(
         function(response) {
-          if (RequestService.complete_statuses.indexOf(response.data.status) == -1) {
+          if (RequestService.completeStatuses.indexOf(response.data.status) == -1) {
             // If request isn't done then we need to keep checking
             $timeout(function() {
               checkForCompletion(id);

--- a/brew_view/static/src/js/services/sf_builder_service.js
+++ b/brew_view/static/src/js/services/sf_builder_service.js
@@ -1,41 +1,47 @@
 import angular from 'angular';
 
 sfPostProcessor.$inject = ['postProcess', 'schemaForm'];
+
+/**
+ * sfPostProcessor - Post processes a Schema-Form (from angular-schema-form) to includes
+ * our rules about nullable objects since angular-schema-form does not like the concept
+ * very much.
+ * @param  {type} postProcess description
+ * @param  {type} schemaForm  description
+ */
 export function sfPostProcessor(postProcess, schemaForm) {
-
   postProcess.addPostProcess(function(canonicalForm) {
-
     // Validators
-    var requiredAllowNull = function(modelValue, viewValue) {
+    let requiredAllowNull = function(modelValue, viewValue) {
       return !(modelValue === undefined);
     };
-    var failNull = function(modelValue, viewValue) {
+    let failNull = function(modelValue, viewValue) {
       return !(modelValue === null);
-    }
+    };
 
     // Parsers
-    var emptyStringToNull = function(modelValue) {
+    let emptyStringToNull = function(modelValue) {
       return modelValue === '' ? null : modelValue;
-    }
+    };
 
-    for(var i=0; i<canonicalForm.length; i++) {
+    for (let i=0; i<canonicalForm.length; i++) {
       schemaForm.traverseForm(canonicalForm[i], function(formObj) {
-        if(formObj.schema) {
-
-          var validators = {};
-          if(!!formObj.schema.requiredAllowNull) {
+        if (formObj.schema) {
+          let validators = {};
+          if (!!formObj.schema.requiredAllowNull) {
             validators['requiredAllowNull'] = requiredAllowNull;
           }
-          if(!!formObj.schema.failNull) {
+          if (!!formObj.schema.failNull) {
             validators['failNull'] = failNull;
           }
           formObj.$validators = angular.merge({}, formObj.$validators, validators);
 
-          var parsers = [];
-          if(formObj.schema.type.indexOf('string') != -1 && formObj.schema.nullable) {
+          let parsers = [];
+          if (formObj.schema.type.indexOf('string') != -1 && formObj.schema.nullable) {
             parsers.push(emptyStringToNull);
           }
-          formObj.$parsers = formObj.$parsers === undefined ? parsers : formObj.$parsers.concat(parsers);
+          formObj.$parsers = formObj.$parsers === undefined ?
+            parsers : formObj.$parsers.concat(parsers);
         }
       });
     }
@@ -44,15 +50,28 @@ export function sfPostProcessor(postProcess, schemaForm) {
 };
 
 sfErrorMessageConfig.$inject = ['sfErrorMessageProvider'];
+
+/**
+ * sfErrorMessageConfig - Setup default error messages for nullable problems.
+ * @param  {Object} sfErrorMessageProvider Provider from angular-schema-form
+ */
 export function sfErrorMessageConfig(sfErrorMessageProvider) {
   sfErrorMessageProvider.setDefaultMessage('requiredAllowNull', 'Required');
   sfErrorMessageProvider.setDefaultMessage('failNull', 'Required');
 };
 
 sfBuilderService.$inject = ['$rootScope', 'sfPath', 'UtilityService'];
-export function sfBuilderService($rootScope, sfPath, UtilityService) {
 
-  var SFBuilderService = {};
+/**
+ * sfBuilderService - Service for converting systems, commands, and parameters into valid
+ * schema-form objects for use by angular-schema-form.
+ * @param  {$rootScope} $rootScope Angular's $rootScope object.
+ * @param  {string} sfPath         Schema-form path.
+ * @param  {Object} UtilityService UtilityService for version/config API.
+ * @return {Object}                A Service for building valid schema-form objects.
+ */
+export function sfBuilderService($rootScope, sfPath, UtilityService) {
+  let SFBuilderService = {};
 
   /**
    * Returns a valid schema / form combination for use in angular-schema-form
@@ -64,151 +83,208 @@ export function sfBuilderService($rootScope, sfPath, UtilityService) {
    *
    * @param {Object} system - A valid beer-garden System object
    * @param {Object} command - A valid beer-garden Command object
-   * @returns {Object} schemaForm - An object with schema and form properties
+   * @return {Object} schemaForm - An object with schema and form properties
    */
   SFBuilderService.build = function(system, command) {
-
     // Build the actual schema and form for this specific command
-    var modelSF = SFBuilderService.buildModelSF(command, ['parameters']);
+    let modelSF = SFBuilderService.buildModelSF(command, ['parameters']);
+    let modelSchema;
+    let modelForm;
 
     // Merge the two into the final representation
     // For the schema start with common and add the model to its parameters
     // If the command has a custom schema then use that instead of the generated one
-    if(command.schema !== undefined && !angular.equals({}, command.schema)) {
-      var modelSchema = {type: 'object', properties: command.schema};
-    }
-    else {
-      var modelSchema = {type: 'object', properties: modelSF['schema']};
+    if (command.schema !== undefined && !angular.equals({}, command.schema)) {
+      modelSchema = {type: 'object', properties: command.schema};
+    } else {
+      modelSchema = {type: 'object', properties: modelSF['schema']};
     }
 
     // Form is a little more tricky
     // If the command has a custom form then use that instead of the generated one
-    if(command.form !== undefined && !angular.equals({}, command.form) && !angular.equals([], command.form)) {
-      var modelForm = angular.isArray(command.form) ? command.form : [command.form];
-    }
-    else {
-      var modelForm = [], required = [], optional = [];
+    if (command.form !== undefined &&
+        !angular.equals({}, command.form) &&
+        !angular.equals([], command.form)) {
+      modelForm = angular.isArray(command.form) ? command.form : [command.form];
+    } else {
+      modelForm = [];
+      let required = [];
+      let optional = [];
 
       angular.forEach(modelSF['form'], function(item) {
         // Form items can be either a string or dictionary with a key parameter
-        var itemKey = typeof item === 'string' ? item : item.key;
+        let itemKey = typeof item === 'string' ? item : item.key;
 
         // The actual key itself should be an array, but if not we need to make it one
-        itemKey = typeof itemKey === 'string' ?  sfPath.parse(itemKey) : itemKey;
-        var schemaItem = modelSchema['properties'][itemKey[itemKey.length-1]];
+        itemKey = typeof itemKey === 'string' ? sfPath.parse(itemKey) : itemKey;
+        let schemaItem = modelSchema['properties'][itemKey[itemKey.length-1]];
 
-        if(schemaItem.optional) {
+        if (schemaItem.optional) {
           optional.push(item);
-        }
-        else {
+        } else {
           required.push(item);
         }
       });
 
-      if(optional.length) {
-        if(!required.length) {
-          required.push({ 'type': 'help', 'helpvalue': '<div uib-alert class="alert alert-info m-b-0">None! :)</div>' });
+      if (optional.length) {
+        if (!required.length) {
+          required.push(
+            {'type': 'help',
+             'helpvalue': '<div uib-alert class="alert alert-info m-b-0">None! :)</div>'}
+           );
         }
         modelForm.push({
           'type': 'tabs',
           'tabs': [
             {'title': 'Required Fields', 'items': required},
-            {'title': 'Optional Fields', 'items': optional}
-          ]
+            {'title': 'Optional Fields', 'items': optional},
+          ],
         });
-      }
-      else {
+      } else {
         modelForm = required;
       }
     }
 
     // Build the schema and form common to all commands
-    var commonSF = SFBuilderService.buildCommonSF(system, command);
+    let commonSF = SFBuilderService.buildCommonSF(system, command);
 
     // Tie in the model schema in the correct place
     commonSF['schema']['parameters'] = modelSchema;
 
     return {
-      schema: { type: 'object', properties: commonSF['schema'] },
-      form: modelForm.concat(commonSF['form'])
+      schema: {type: 'object', properties: commonSF['schema']},
+      form: modelForm.concat(commonSF['form']),
     };
   };
 
-  /**
-  * Builds the schema and form common to all commands.
-  */
-  SFBuilderService.buildCommonSF = function(system, command) {
 
+  /**
+   * buildCommonSF - * Builds the schema and form common to all commands.
+   * @param  {Object} system  beer-garden system object.
+   * @param  {Object} command beer-gardne command object.
+   * @return {Object}         Schema-form object that is common to all commands.
+   */
+  SFBuilderService.buildCommonSF = function(system, command) {
     // SCHEMA
-    var instance_names = [];
-    angular.forEach(system.instances, function(instance){
-      instance_names.push(instance.name);
+    let instanceNames = [];
+    angular.forEach(system.instances, function(instance) {
+      instanceNames.push(instance.name);
     });
 
-    var commonSchema = {
-      'system': { 'title': 'System Name', 'type': 'string', 'default': system.name, 'required': true },
-      'system_version': { 'title': 'System Version', 'type': 'string', 'default': system.version, 'required': true },
-      'command': { 'title': 'Command Name', 'type': 'string', 'default': command.name, 'required': true },
-      'comment': { 'title': 'Comment', 'type': 'string', 'default': '', 'required': false, 'maxLength': 140,
-        'validationMessage': 'Maximum comment length is 140 characters' },
-      'output_type': { 'title': 'Output Type', 'type': 'string', 'default': command.output_type, 'required': false },
-      'instance_name': { 'title': 'Instance Name', 'type': 'string', 'required': true }
+    let commonSchema = {
+      'system': {
+        'title': 'System Name', 'type': 'string',
+        'default': system.name, 'required': true,
+      },
+      'system_version': {
+        'title': 'System Version', 'type': 'string',
+        'default': system.version, 'required': true,
+      },
+      'command': {
+        'title': 'Command Name', 'type': 'string',
+        'default': command.name, 'required': true,
+      },
+      'comment': {
+        'title': 'Comment', 'type': 'string',
+        'default': '', 'required': false,
+        'maxLength': 140,
+        'validationMessage': 'Maximum comment length is 140 characters',
+      },
+      'output_type': {
+        'title': 'Output Type', 'type': 'string',
+        'default': command.output_type, 'required': false,
+      },
+      'instance_name': {
+        'title': 'Instance Name', 'type': 'string',
+        'required': true,
+      },
     };
 
-    if(system.instances.length == 1) {
-      commonSchema['instance_name']['default'] = instance_names[0];
+    if (system.instances.length == 1) {
+      commonSchema['instance_name']['default'] = instanceNames[0];
       commonSchema['instance_name']['readonly'] = true;
     }
 
     // FORM
-    var instance_help = {
-       'type': 'help', 'helpvalue': '<div uib-alert class="alert alert-warning m-b-0">Instance is not RUNNING, but you can still "Make Request"</div><br>', 'condition': "checkInstance(instance_name)"
+    const instanceHelp = {
+      'type': 'help',
+      'helpvalue': '<div uib-alert class="alert alert-warning m-b-0">Instance is not RUNNING, ' +
+                   'but you can still "Make Request"</div><br>',
+      'condition': 'checkInstance(instance_name)',
     };
 
-    var systemSection = {
-      'type': 'section',
-      'htmlClass': 'row',
-      'items' : [
-        { 'key': 'system', 'feedback': false, 'disableSuccessState': true, 'disableErrorState': true, 'readonly': true, 'required': true, 'htmlClass': 'col-md-3' },
-        { 'key': 'system_version',  'feedback': false, 'disableSuccessState': true, 'disableErrorState': true, 'readonly': true, 'required': true, 'htmlClass': 'col-md-3' },
-        { 'key': 'command', 'feedback': false, 'disableSuccessState': true, 'disableErrorState': true, 'readonly': true, 'required': true, 'htmlClass': 'col-md-3' },
-        { 'key': 'instance_name', 'feedback': false, 'disableSuccessState': true, 'htmlClass': 'col-md-3', 'type': 'select', 'choices': {'titleMap': instance_names}}
-      ]
-    };
-
-    var hr = { 'type': 'help', 'helpvalue': '<hr>' };
-    var comment = { 'key': 'comment', 'type': 'textarea', 'feedback': true, 'disableSuccessState': false,
-      'disableErrorState': false, 'readonly': false, 'required': false, 'fieldHtmlClass': 'm-b-3' }
-
-    var buttonSection = {
+    const systemSection = {
       'type': 'section',
       'htmlClass': 'row',
       'items': [
-        { 'type': 'button', 'style': 'btn-warning w-100 ', 'title': 'Reset', 'onClick': 'reset(ngform, model, system, command.data)', 'htmlClass': "col-md-2" },
-        { 'type': 'submit', 'style': 'btn-primary w-100', 'title': 'Make Request', 'htmlClass': "col-md-10" }
-      ]
+        {
+          'key': 'system', 'feedback': false, 'disableSuccessState': true,
+          'disableErrorState': true, 'readonly': true, 'required': true,
+          'htmlClass': 'col-md-3',
+        },
+        {
+          'key': 'system_version', 'feedback': false, 'disableSuccessState': true,
+          'disableErrorState': true, 'readonly': true, 'required': true,
+          'htmlClass': 'col-md-3',
+        },
+        {
+          'key': 'command', 'feedback': false, 'disableSuccessState': true,
+          'disableErrorState': true, 'readonly': true, 'required': true,
+          'htmlClass': 'col-md-3',
+        },
+        {
+          'key': 'instance_name', 'feedback': false, 'disableSuccessState': true,
+          'htmlClass': 'col-md-3', 'type': 'select', 'choices': {'titleMap': instanceNames},
+        },
+      ],
     };
 
-    var commonForm = { 'type': 'fieldset', 'items': [hr, systemSection, comment, instance_help, buttonSection] };
+    const hr = {'type': 'help', 'helpvalue': '<hr>'};
+    const comment = {
+      'key': 'comment', 'type': 'textarea', 'feedback': true, 'disableSuccessState': false,
+      'disableErrorState': false, 'readonly': false, 'required': false, 'fieldHtmlClass': 'm-b-3',
+    };
+
+    const buttonSection = {
+      'type': 'section',
+      'htmlClass': 'row',
+      'items': [
+        {
+          'type': 'button', 'style': 'btn-warning w-100 ', 'title': 'Reset',
+          'onClick': 'reset(ngform, model, system, command.data)', 'htmlClass': 'col-md-2',
+        },
+        {
+          'type': 'submit', 'style': 'btn-primary w-100',
+          'title': 'Make Request', 'htmlClass': 'col-md-10',
+        },
+      ],
+    };
+
+    const commonForm = {
+      'type': 'fieldset', 'items': [hr, systemSection, comment, instanceHelp, buttonSection],
+    };
 
     return {
       schema: commonSchema,
-      form: commonForm
+      form: commonForm,
     };
   };
 
+
   /**
-   * Build a schema and form for an object model.
+   * buildModelSf - Build a schema and form for an object model.
+   * @param  {Object} model     Parameter Model.
+   * @param  {string} parentKey The key representing this model's parent.
+   * @return {Object}           Schema-Form object for use by angular-schema-form.
    */
   SFBuilderService.buildModelSF = function(model, parentKey) {
+    let paramSchemas = {};
+    let paramForms = [];
 
-    var paramSchemas = {};
-    var paramForms = [];
-
-    for(var i=0, len=model.parameters.length; i<len; i++) {
-      var parameter = model.parameters[i];
-      var key = parameter.key;
-      var sf = SFBuilderService.buildParameterSF(parameter, parentKey);
+    for (let i=0, len=model.parameters.length; i<len; i++) {
+      let parameter = model.parameters[i];
+      let key = parameter.key;
+      let sf = SFBuilderService.buildParameterSF(parameter, parentKey);
 
       paramSchemas[key] = sf['schema'];
       paramForms.push(sf['form']);
@@ -216,41 +292,43 @@ export function sfBuilderService($rootScope, sfPath, UtilityService) {
 
     return {
       schema: paramSchemas,
-      form: paramForms
+      form: paramForms,
     };
   };
 
-  /**
-  * Build a schema and form for an individual parameter.
-  */
-  SFBuilderService.buildParameterSF = function(parameter, parentKey, inArray) {
 
+  /**
+   * buildParameterSF - Build a schema and form for an individual parameter.
+   * @param  {Object} parameter Beer-garden parameter object.
+   * @param  {string} parentKey The key representing this parameter's parent.
+   * @param  {boolean} inArray  Flag to determine if the parameter is part of an array.
+   * @return {Object}           Schema-Form object for use by angular-schema-form.
+   */
+  SFBuilderService.buildParameterSF = function(parameter, parentKey, inArray) {
     // Schema and form that are the same across all parameters
-    var generalSF = {
+    let generalSF = {
       'schema': {
         'title': parameter.display_name,
         'optional': parameter.optional,
         'nullable': parameter.nullable,
-        'description': UtilityService.escapeHtml(parameter.description)
+        'description': UtilityService.escapeHtml(parameter.description),
       },
       'form': {
-        'key': parentKey.concat(parameter.key)
-      }
-    }
+        'key': parentKey.concat(parameter.key),
+      },
+    };
 
-    if(inArray) {
+    if (inArray) {
       generalSF['form']['key'].push('');
     }
 
     // Type-specific schema / forms
-    var builderFunction;
-    if(parameter.multi && !inArray) {
+    let builderFunction;
+    if (parameter.multi && !inArray) {
       builderFunction = SFBuilderService.buildMultiParameterSF;
-    }
-    else if(parameter.parameters && parameter.parameters.length > 0) {
+    } else if (parameter.parameters && parameter.parameters.length > 0) {
       builderFunction = SFBuilderService.buildModelParameterSF;
-    }
-    else {
+    } else {
       builderFunction = SFBuilderService.buildSimpleParameterSF;
     }
 
@@ -260,129 +338,122 @@ export function sfBuilderService($rootScope, sfPath, UtilityService) {
   // Build a schema and form for a parameter that's not a dictionary
   // and not an array
   SFBuilderService.buildSimpleParameterSF = function(parameter, parentKey, inArray) {
-
-    var baseSF = baseSchemaForm(parameter.type);
-    var schema = baseSF['schema'], form = baseSF['form'];
+    let baseSF = baseSchemaForm(parameter.type);
+    let schema = baseSF['schema'];
+    let form = baseSF['form'];
 
     // If the set a form_input_type, we apply it to the form
-    applyConstraint(form, 'type', parameter.form_input_type)
+    applyConstraint(form, 'type', parameter.form_input_type);
 
     // Deal with 'requiredness'
-    // ASF does some mangling before its 'required' validation, most annoyingly making empty strings appear undefined.
-    // So we have our own validation based on if the parameter is optional and whether nulls are allowed.
-    // Booleans special. The only way they could 'fail' would be if they were nullable with a null
-    // default. If that's allowed it would require two clicks to be 'false' and look the same as how it started.
-    if(schema['type'].indexOf('boolean') === -1) {
-      if(!parameter.optional) {
+    // ASF does some mangling before its 'required' validation, most annoyingly making empty
+    // strings appear undefined. So we have our own validation based on if the parameter is
+    // optional and whether nulls are allowed.
+    // Booleans are special. The only way they could 'fail' would be if they were nullable
+    // with a null default. If that's allowed it would require two clicks to be 'false' and
+    // look the same as how it started.
+    if (schema['type'].indexOf('boolean') === -1) {
+      if (!parameter.optional) {
         schema[parameter.nullable ? 'requiredAllowNull' : 'required'] = true;
       }
 
-      if(!parameter.nullable) {
+      if (!parameter.nullable) {
         schema['failNull'] = true;
       }
     }
 
-    // Now we do some setup that only makes sense if we aren't inside an array, because if we are we want to apply
-    // these things to the array itself, not this
-    if(!inArray) {
-
+    // Now we do some setup that only makes sense if we aren't inside an array, because if we
+    // are we want to apply these things to the array itself, not this
+    if (!inArray) {
       // Set up the default model value for this parameter
-      // FYI - It's a good idea to only specify a default for things that need it, as a default can cause ASF to treat
-      // the field differently.
+      // FYI - It's a good idea to only specify a default for things that need it, as a default
+      // can cause ASF to treat the field differently.
       // Parameters with NO default will not show in the model preview until they get a value.
-      var defaultValue = correctDefault(parameter, schema['type']);
-      if(defaultValue !== undefined) {
-        if(defaultValue !== null || parameter.nullable) {
+      let defaultValue = correctDefault(parameter, schema['type']);
+      if (defaultValue !== undefined) {
+        if (defaultValue !== null || parameter.nullable) {
           schema['default'] = defaultValue;
         }
       }
 
       // Now map constraints that depend on the type into the schema and form
-      if(schema['type'].indexOf('string') !== -1) {
+      if (schema['type'].indexOf('string') !== -1) {
         applyConstraint(schema, 'maxLength', parameter['maximum']);
         applyConstraint(schema, 'minLength', parameter['minimum']);
         applyConstraint(schema, 'pattern', parameter['regex']);
-      }
-      else if(schema['type'].indexOf('integer') !== -1 || schema['type'].indexOf('number') !== -1) {
+      } else if (schema['type'].indexOf('integer') !== -1 ||
+                 schema['type'].indexOf('number') !== -1) {
         applyConstraint(schema, 'maximum', parameter['maximum']);
         applyConstraint(schema, 'minimum', parameter['minimum']);
       }
     }
 
     // Now wire up dynamic choices
-    if(parameter.choices && !angular.equals(parameter.choices, {})) {
-
+    if (parameter.choices && !angular.equals(parameter.choices, {})) {
       // First determine what form element to use
-      if(parameter.choices.display) {
-        if(parameter.choices.display === 'typeahead') {
+      if (parameter.choices.display) {
+        if (parameter.choices.display === 'typeahead') {
           form['type'] = 'typeahead';
-        } else if(parameter.choices.display === 'select') {
+        } else if (parameter.choices.display === 'select') {
           form['type'] = 'select';
         } else {
           form['type'] = 'typeahead';
-          console.error("Don't know how to render choices type '" +
-            parameter.choices.type + "', defaulting to 'typeahead' " +
-            "(valid options are 'typeahead' and 'select')");
+          console.error('Don\'t know how to render choices type \'' +
+            parameter.choices.type + '\', defaulting to \'typeahead\' ' +
+            '(valid options are \'typeahead\' and \'select\')');
         }
       } else {
         form['type'] = 'typeahead';
       }
 
       // Then determine if it should be strict (only really affects typeaheads)
-      if(parameter.choices.strict) {
+      if (parameter.choices.strict) {
         form['strict'] = true;
       }
 
       // Then populate the choices
       // Simple case - static list of choices
-      if(parameter.choices.type === 'static') {
-        form['choices'] = { titleMap: parameter.choices.value };
+      if (parameter.choices.type === 'static') {
+        form['choices'] = {titleMap: parameter.choices.value};
 
-        if(parameter.choices.details && parameter.choices.details.key_reference) {
-          var field = parentKey + '.' + parameter.choices.details.key_reference;
+        if (parameter.choices.details && parameter.choices.details.key_reference) {
+          let field = parentKey + '.' + parameter.choices.details.key_reference;
 
           form['choices']['updateOn'] = field;
           form['choices']['transforms'] = [{lookupField: field}];
         }
-      }
-
-      // Get choices from a URL
-      else if(parameter.choices.type === 'url') {
+      } else if (parameter.choices.type === 'url') {
         form['choices'] = {
           updateOn: [],
           httpGet: {
             url: parameter.choices.details['address'],
-            queryParameterFields: {}
-          }
+            queryParameterFields: {},
+          },
         };
 
-        for(var i=0; i<parameter.choices.details['args'].length; i++) {
-          var pair = parameter.choices.details['args'][i];
-          var field = parentKey + '.' + pair[1];
+        for (let i=0; i<parameter.choices.details['args'].length; i++) {
+          let pair = parameter.choices.details['args'][i];
+          let field = parentKey + '.' + pair[1];
 
           form['choices']['updateOn'].push(field);
           form['choices']['httpGet']['queryParameterFields'][pair[0]] = field;
         }
-      }
-
-      // Get choices by making a request to another command
-      else if (parameter.choices.type === 'command') {
-
+      } else if (parameter.choices.type === 'command') {
         form['choices'] = {
           updateOn: [],
           callback: {
             function: 'createRequestWrapper',
             arguments: [{
               command: parameter.choices.details['name'],
-              parameterNames: []
+              parameterNames: [],
             }],
-            argumentFields: []
-          }
+            argumentFields: [],
+          },
         };
 
-        for(var i=0; i<parameter.choices.details['args'].length; i++) {
-          var pair = parameter.choices.details['args'][i];
-          var field = parentKey + '.' + pair[1];
+        for (let i=0; i<parameter.choices.details['args'].length; i++) {
+          let pair = parameter.choices.details['args'][i];
+          let field = parentKey + '.' + pair[1];
 
           form['choices']['updateOn'].push(field);
           form['choices']['callback']['argumentFields'].push(field);
@@ -390,21 +461,20 @@ export function sfBuilderService($rootScope, sfPath, UtilityService) {
         }
 
         // If it's an object then it's a fully specified command
-        if(typeof parameter.choices.value === 'object') {
+        if (typeof parameter.choices.value === 'object') {
           Object.assign(form['choices']['callback']['arguments'][0], {
             system: parameter.choices.value.system,
             system_version: parameter.choices.value.system_version,
-            instance_name: parameter.choices.value.instance_name
+            instance_name: parameter.choices.value.instance_name,
           });
         }
-      }
-      else {
-        console.error("Don't know how to handle parameter '%s' choices type (%s)",
+      } else {
+        console.error('Don\'t know how to handle parameter \'%s\' choices type (%s)',
           parameter.key, parameter.choices.type);
       }
 
-      if(parameter.nullable && form['type'] === 'select') {
-        if(!Array.isArray(form['choices']['transforms'])) {
+      if (parameter.nullable && form['type'] === 'select') {
+        if (!Array.isArray(form['choices']['transforms'])) {
           form['choices']['transforms'] = [];
         }
 
@@ -412,15 +482,14 @@ export function sfBuilderService($rootScope, sfPath, UtilityService) {
       }
     }
 
-    return { schema: schema, form: form };
+    return {schema: schema, form: form};
   };
 
   SFBuilderService.buildMultiParameterSF = function(parameter, parentKey) {
-
     // Multi parameters are represented as 'array' types with their real type
     // definition in the 'items' definition. So first we need to construct the
     // schema and form for this as if it weren't a multi.
-    var nestedSF = SFBuilderService.buildParameterSF(parameter, parentKey, true);
+    let nestedSF = SFBuilderService.buildParameterSF(parameter, parentKey, true);
 
     // Now tweak the result to make sense as an array item
     // We are assuming the default for this parameter is intended for the array,
@@ -434,24 +503,24 @@ export function sfBuilderService($rootScope, sfPath, UtilityService) {
 
     // A nullable object is a distinct thing and doesn't make sense inside an
     // array (would be the same as an empty array)
-    if(nestedSF['schema']['type'] === 'object') {
+    if (nestedSF['schema']['type'] === 'object') {
       nestedSF['schema']['nullable'] = false;
     }
 
-    var arraySF = {
+    let arraySF = {
       schema: {
         type: ['array', 'null'],
-        items: nestedSF['schema']
+        items: nestedSF['schema'],
       },
       form: {
         startEmpty: !!parameter.nullable,
-        items: [ nestedSF['form'] ]
-      }
+        items: [nestedSF['form']],
+      },
     };
 
     // Only add a default if necessary, otherwise it breaks things
-    var arrayDefault = correctDefault(parameter, 'array');
-    if(arrayDefault !== undefined) {
+    let arrayDefault = correctDefault(parameter, 'array');
+    if (arrayDefault !== undefined) {
       arraySF['schema']['default'] = arrayDefault;
       arraySF['form']['startEmpty'] = true;
     }
@@ -464,33 +533,34 @@ export function sfBuilderService($rootScope, sfPath, UtilityService) {
   };
 
   SFBuilderService.buildModelParameterSF = function(parameter, parentKey, inArray) {
+    let newParentKey = inArray ?
+      parentKey.concat(parameter.key, '') : parentKey.concat(parameter.key);
+    let innerSF = SFBuilderService.buildModelSF(parameter, newParentKey);
+    let objDefault = correctDefault(parameter, 'object');
 
-    var newParentKey = inArray ? parentKey.concat(parameter.key, "") : parentKey.concat(parameter.key);
-    var innerSF = SFBuilderService.buildModelSF(parameter, newParentKey);
-    var objDefault = correctDefault(parameter, 'object');
-
-    var form = {}, schema = {
+    let form = {};
+    let schema = {
       type: 'object',
       partition: '!optional',
       accordionHeading: 'Optional Fields',
-      properties: innerSF['schema']
+      properties: innerSF['schema'],
     };
 
-    if(parameter.optional && parameter.nullable && angular.equals({}, objDefault) && !inArray) {
+    if (parameter.optional && parameter.nullable && angular.equals({}, objDefault) && !inArray) {
       schema['format'] = 'nullable';
     } else {
       schema['default'] = objDefault;
       form['items'] = innerSF['form'];
     }
 
-    return { schema: schema, form: form };
+    return {schema: schema, form: form};
   };
 
   // Get a basic schema and form for a given parameter type
-  var baseSchemaForm = function(parameterType) {
-    var type = parameterType.toLowerCase();
+  const baseSchemaForm = function(parameterType) {
+    let type = parameterType.toLowerCase();
 
-    var typeMap = {
+    let typeMap = {
       any: 'variant',
       integer: 'integer',
       float: 'number',
@@ -498,40 +568,38 @@ export function sfBuilderService($rootScope, sfPath, UtilityService) {
       dictionary: 'dictionary',
       string: 'string',
       date: 'integer',
-      datetime: 'integer'
+      datetime: 'integer',
     };
 
     // We want the schema type to default to 'string' and always also allow 'null'.
     // That way we have finer-grained control over when null is allowed.
-    var schema = {
-      type: [typeMap[type] || 'string', 'null']
+    let schema = {
+      type: [typeMap[type] || 'string', 'null'],
     };
-    var form = {};
+    let form = {};
 
     // Certain types require additional options
-    if(type === 'date') {
+    if (type === 'date') {
       schema['format'] = 'datetime';
       form['options'] = {format: 'MM/DD/YYYY'};
-    }
-    else if (type === 'datetime') {
+    } else if (type === 'datetime') {
       schema['format'] = 'datetime';
     }
 
-    return { schema: schema, form: form };
+    return {schema: schema, form: form};
   };
 
-  var correctDefault = function(parameter, type) {
-
-    switch(type) {
+  const correctDefault = function(parameter, type) {
+    switch (type) {
       case 'boolean':
         return parameter.nullable && parameter.default === null ? null : !!parameter.default;
 
       // If the default is null then default to an empty array
       // Otherwise create a deep copy of the default
       case 'array':
-        if( !!parameter.default ) {
+        if ( !!parameter.default ) {
           return $.extend(true, [], parameter.default);
-        } else if( parameter.default === null && parameter.nullable ) {
+        } else if ( parameter.default === null && parameter.nullable ) {
           return null;
         } else {
           return undefined;
@@ -539,7 +607,7 @@ export function sfBuilderService($rootScope, sfPath, UtilityService) {
 
       // If default is defined then return a deep copy, otherwise an empty object
       case 'object':
-        if( !!parameter.default ) {
+        if ( !!parameter.default ) {
           return $.extend(true, {}, parameter.default);
         } else {
           return {};
@@ -550,8 +618,8 @@ export function sfBuilderService($rootScope, sfPath, UtilityService) {
     }
   };
 
-  var applyConstraint = function(object, createKey, paramValue) {
-    if(angular.isDefined(paramValue) && paramValue !== null) {
+  const applyConstraint = function(object, createKey, paramValue) {
+    if (angular.isDefined(paramValue) && paramValue !== null) {
       object[createKey] = paramValue;
     }
   };

--- a/brew_view/static/src/js/services/system_service.js
+++ b/brew_view/static/src/js/services/system_service.js
@@ -1,46 +1,54 @@
 
 systemService.$inject = ['$http'];
+
+
+/**
+ * systemService - Service for getting systems from the API.
+ * @param  {$http} $http Angular's $http object.
+ * @return {Object}      Object for interacting with the system API.
+ */
 export default function systemService($http) {
-  var SystemService = {};
+  let SystemService = {};
 
   SystemService.startSystem = function(system) {
     return $http.patch('api/v1/instances/' + system.instances[0].id,
       {operations: [{operation: 'replace', path: '/status', value: 'starting'}]}
     );
-  }
+  };
 
   SystemService.stopSystem = function(system) {
     return $http.patch('api/v1/instances/' + system.instances[0].id,
       {operations: [{operation: 'replace', path: '/status', value: 'stopping'}]}
     );
-  }
+  };
 
   SystemService.reloadSystem = function(system) {
     return $http.patch('api/v1/systems/' + system.id,
       {operations: [{operation: 'reload', path: '', value: ''}]}
     );
-  }
+  };
 
   SystemService.deleteSystem = function(system) {
     return $http.delete('api/v1/systems/' + system.id);
-  }
+  };
 
   SystemService.getSystems = function() {
     return $http.get('api/v1/systems');
-  }
+  };
 
-  SystemService.getSystem = function(id, include_commands) {
-    return $http.get('api/v1/systems/' + id, {params: {include_commands: include_commands}});
-  }
+  SystemService.getSystem = function(id, includeCommands) {
+    return $http.get('api/v1/systems/' + id, {params: {include_commands: includeCommands}});
+  };
 
   SystemService.getSystemID = function(request) {
-    var promise = $http.get('api/v1/systems', {params: {name: request.system, include_commands: true} })
+    const promise = $http.get('api/v1/systems',
+      {params: {name: request.system, include_commands: true}})
       .then(function(response) {
-        var systemId = null;
-        if(response.data.length > 0) {
-          for(var i = 0; i < response.data[0].commands.length; i++) {
-            var command = response.data[0].commands[i]
-            if(command.name === request.command) {
+        let systemId = null;
+        if (response.data.length > 0) {
+          for (let i = 0; i < response.data[0].commands.length; i++) {
+            let command = response.data[0].commands[i];
+            if (command.name === request.command) {
               systemId = command.system.id;
               break;
             }

--- a/brew_view/static/src/js/services/utility_service.js
+++ b/brew_view/static/src/js/services/utility_service.js
@@ -20,7 +20,7 @@ export default function utilityService($rootScope, $http) {
       });
     } else {
       let newO = {};
-      for (origKey in o) {
+      for (const origKey in o) {
         if (o.hasOwnProperty(origKey)) {
           let value = o[origKey];
           let newKey = origKey.replace(/(\_\w)/g, function(m) {
@@ -39,10 +39,10 @@ export default function utilityService($rootScope, $http) {
 
   UtilityService.getIcon = function(iconName) {
     if (iconName === undefined || iconName == null) {
-      if ($rootScope.config === undefined || $rootScope.config.icon_default === undefined) {
+      if ($rootScope.config === undefined || $rootScope.config.iconDefault === undefined) {
         return '';
       } else {
-        iconName = $rootScope.config.icon_default;
+        iconName = $rootScope.config.iconDefault;
       }
     }
 

--- a/brew_view/static/src/js/services/utility_service.js
+++ b/brew_view/static/src/js/services/utility_service.js
@@ -1,36 +1,66 @@
 
 utilityService.$inject = ['$rootScope', '$http'];
+
+/**
+ * utilityService - Used for getting configurations/icons and formatting
+ * @param  {$rootScope} $rootScope Angular's $rootScope object
+ * @param  {$http} $http           Angular's $http object
+ * @return {Object}                For use by a controller.
+ */
 export default function utilityService($rootScope, $http) {
-  var UtilityService = {};
+  let UtilityService = {};
+
+  UtilityService.camelCaseKeys = function(o) {
+    if (o instanceof Array) {
+      return o.map(function(value) {
+        if (typeof value === 'object') {
+          value = camelCaseKeys(value);
+        }
+        return value;
+      });
+    } else {
+      let newO = {};
+      for (origKey in o) {
+        if (o.hasOwnProperty(origKey)) {
+          let value = o[origKey];
+          let newKey = origKey.replace(/(\_\w)/g, function(m) {
+            return m[1].toUpperCase();
+          });
+          newO[newKey] = value;
+        }
+      }
+      return newO;
+    }
+  };
 
   UtilityService.getConfig = function() {
     return $http.get('config');
   };
 
-  UtilityService.getIcon = function(icon_name) {
-    if(icon_name === undefined || icon_name == null) {
-      if($rootScope.config === undefined || $rootScope.config.icon_default === undefined) {
-        return "";
+  UtilityService.getIcon = function(iconName) {
+    if (iconName === undefined || iconName == null) {
+      if ($rootScope.config === undefined || $rootScope.config.icon_default === undefined) {
+        return '';
       } else {
-        icon_name = $rootScope.config.icon_default;
+        iconName = $rootScope.config.icon_default;
       }
     }
 
-    return icon_name.substring(0, icon_name.indexOf('-')) + ' ' + icon_name;
+    return iconName.substring(0, iconName.indexOf('-')) + ' ' + iconName;
   };
 
-  var re = /[&<>"'/]/g;
-  var entityMap = {
-    "&": "&amp;",
-    "<": "&lt;",
-    ">": "&gt;",
-    "\"": "&quot;",
-    "'": "&#39;",
-    "/": "&#x2F;",
+  let re = /[&<>"'/]/g;
+  let entityMap = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    '\'': '&#39;',
+    '/': '&#x2F;',
   };
 
   UtilityService.escapeHtml = function(html) {
-    if(html) {
+    if (html) {
       return String(html).replace(re, function(s) {
         return entityMap[s];
       });
@@ -46,7 +76,7 @@ export default function utilityService($rootScope, $http) {
       maxLines: 30,
       readOnly: readOnly,
       showLineNumbers: false,
-      showPrintMargin: false
+      showPrintMargin: false,
     });
     _editor.setTheme('ace/theme/dawn');
     _editor.session.setMode('ace/mode/json');
@@ -54,7 +84,7 @@ export default function utilityService($rootScope, $http) {
     _editor.session.setUseWorker(!readOnly);
     _editor.$blockScrolling = Infinity;
 
-    if(readOnly) {
+    if (readOnly) {
       _editor.renderer.$cursorLayer.element.style.opacity = 0;
     }
   };

--- a/brew_view/static/src/js/services/version_service.js
+++ b/brew_view/static/src/js/services/version_service.js
@@ -1,26 +1,32 @@
 
 versionService.$inject = ['$http'];
+
+/**
+ * versionService - Wraps API calls to get version information.
+ * @param  {$http} $http Angular's $http service.
+ * @return {Object} for use by controllers.
+ */
 export default function versionService($http) {
   return {
     errorMap: {
       'empty': {
-        'solutions' : [
+        'solutions': [
           {
             problem: 'Request was removed',
             description: 'INFO-type requests are removed after several minutes',
-            resolution:  'Go back to the list of all requests'
+            resolution: 'Go back to the list of all requests',
           },
           {
             problem: 'ID is Incorrect',
             description: 'The ID Specified is incorrect. It does not refer to a valid request',
-            resolution:  'Go back to the list of all requests'
-          }
-        ]
-      }
+            resolution: 'Go back to the list of all requests',
+          },
+        ],
+      },
     },
 
     getVersionInfo: function() {
       return $http.get('version');
-    }
-  }
+    },
+  };
 };

--- a/brew_view/static/src/partials/about.html
+++ b/brew_view/static/src/partials/about.html
@@ -1,4 +1,4 @@
-<h1 class="page-header" ng-cloak>About {{config.application_name}}</h1>
+<h1 class="page-header" ng-cloak>About {{config.applicationName}}</h1>
 
 <div class="container-fluid">
   <div class="row">
@@ -6,9 +6,9 @@
       <div class="panel panel-default">
         <div class="panel-heading">Rest API Documentation</div>
         <div class="panel-body">
-          <p>{{config.application_name}} uses Swagger to provide API documentation. The Swagger UI is actually pretty
+          <p>{{config.applicationName}} uses Swagger to provide API documentation. The Swagger UI is actually pretty
             nice. The Swagger UI will help you explore the commands available to you in the REST Interface.</p>
-          <a class="btn btn-default center-block" href="{{config.url_prefix}}swagger/index.html?config={{config.url_prefix}}config/swagger">Check it out!</a>
+          <a class="btn btn-default center-block" href="{{config.urlPrefix}}swagger/index.html?config={{config.urlPrefix}}config/swagger">Check it out!</a>
         </div>
       </div>
     </div>
@@ -17,7 +17,7 @@
       <div class="panel panel-default animate-if" ng-if="version.loaded">
         <div class="panel-heading">Version Information</div>
         <div class="panel-body">
-          <p>{{config.application_name}} is made up of multiple components. Their versions are listed below</p>
+          <p>{{config.applicationName}} is made up of multiple components. Their versions are listed below</p>
         </div>
         <table class="table table-hover">
           <tr>

--- a/brew_view/static/src/partials/command_view.html
+++ b/brew_view/static/src/partials/command_view.html
@@ -68,7 +68,7 @@
       </div>
     </div>
 
-    <div ng-if="config.debug_mode" class="row" style="padding-bottom: 35px;">
+    <div ng-if="config.debugMode" class="row" style="padding-bottom: 35px;">
       <div class="col-md-4">
         <h3>Command</h3>
         <div ui-ace="{ onLoad: loadPreview }" ng-model="jsonValues.command" style="width: 100%; height: 500px;"></div>

--- a/brew_view/static/src/partials/request_view.html
+++ b/brew_view/static/src/partials/request_view.html
@@ -9,8 +9,8 @@
     <span class="pull-right" ng-if="canRepeat(request.data)">
       <button class="btn btn-success" type="button" ng-click="redoRequest(request.data)">Pour it Again</button>
     </span>
-    <span class="pull-right" ng-if="!canRepeat(request.data) && instance_status != 'RUNNING'">
-        Error: Instance {{instance_status}}
+    <span class="pull-right" ng-if="!canRepeat(request.data) && instanceStatus != 'RUNNING'">
+        Error: Instance {{instanceStatus}}
     </span>
   </h1>
 
@@ -40,13 +40,13 @@
         <tr ng-click="toggleChildren()">
           <td>
             <span id="chevron" class="fa fa-chevron-right" ng-if="hasChildren(request.data)"
-                  ng-class="{'chevron-rotate': !children_collapsed}">
+                  ng-class="{'chevron-rotate': !childrenCollapsed}">
             </span>{{request.data.command}}</td>
           <td>{{request.data.metadata.system_display_name || request.data.system}}</td>
           <td>{{request.data.system_version}}</td>
           <td ng-if="showColumn('instance_name')">{{request.data.instance_name}}</td>
           <td>{{request.data.status}}
-            <span uib-popover="{{status_descriptions[request.data.status]}}"
+            <span uib-popover="{{statusDescriptions[request.data.status]}}"
                 popover-animation="true" popover-placement="right" popover-trigger="'mouseenter'"
                 popover-title="{{request.data.status}}" style="color: gray; padding-top: 5px">
               <span class="glyphicon glyphicon-info-sign"></span>
@@ -80,21 +80,21 @@
       <div class="col-md-6">
         <div style="margin-bottom: 10px;">
           <span class="h3">Output</span>
-          <span ng-show="formatted_available && format_error === undefined" style="margin-top: 9px" class="pull-right">
-            <input bs-switch ng-model="show_formatted" switch-size="mini" type="checkbox" switch-label-width="0"
+          <span ng-show="formattedAvailable && format_error === undefined" style="margin-top: 9px" class="pull-right">
+            <input bs-switch ng-model="showFormatted" switch-size="mini" type="checkbox" switch-label-width="0"
                    switch-handle-width="70" switch-on-text="Collapsible" switch-off-text="Raw">
           </span>
-          <span ng-show="format_error_title !== undefined" class="pull-right" uib-popover="{{format_error_msg}}"
+          <span ng-show="formatErrorTitle !== undefined" class="pull-right" uib-popover="{{formatErrorMsg}}"
                 popover-animation="true" popover-placement="left" popover-trigger="'mouseenter'"
-                popover-title="{{format_error_title}}" style="color: gray; padding-top: 5px">
+                popover-title="{{formatErrorTitle}}" style="color: gray; padding-top: 5px">
             <span class="glyphicon glyphicon-info-sign" style="font-size: 26px"></span>
           </span>
         </div>
         <div style="position: relative;">
-          <pre id="rawOutput" ng-hide="show_formatted">{{raw_output}}</pre>
-          <div id="formattedOutput" ng-show="show_formatted">
-            <div ui-ace="{ onLoad: loadPreview }" ng-model="formatted_output"
-              ng-if="formatted_available && format_error === undefined" style="width: 100%;"></div>
+          <pre id="rawOutput" ng-hide="showFormatted">{{rawOutput}}</pre>
+          <div id="formattedOutput" ng-show="showFormatted">
+            <div ui-ace="{ onLoad: loadPreview }" ng-model="formattedOutput"
+              ng-if="formattedAvailable && format_error === undefined" style="width: 100%;"></div>
           </div>
         </div>
       </div>
@@ -103,7 +103,7 @@
         <div style="margin-bottom: 10px;">
           <span class="h3">Parameters</span>
         </div>
-        <div ui-ace="{ onLoad: loadPreview }" ng-model="formatted_parameters" style="width: 100%;"></div>
+        <div ui-ace="{ onLoad: loadPreview }" ng-model="formattedParameters" style="width: 100%;"></div>
       </div>
     </div>
   </div>

--- a/brew_view/static/webpack.common.js
+++ b/brew_view/static/webpack.common.js
@@ -2,18 +2,16 @@ const path = require('path');
 const webpack = require('webpack');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
-const VisualizerPlugin = require('webpack-visualizer-plugin');
-const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 
 module.exports = {
   entry: {
     index: ['babel-polyfill', path.join(__dirname, 'src', 'index')],
-    dark: path.join(__dirname, 'src/styles/dark', 'dark')
+    dark: path.join(__dirname, 'src/styles/dark', 'dark'),
   },
   output: {
     filename: '[name].js',
     path: path.resolve(__dirname, 'dist'),
-    publicPath: '/dist/'
+    publicPath: '/dist/',
   },
   plugins: [
     new webpack.ProvidePlugin({
@@ -21,7 +19,7 @@ module.exports = {
       '$': 'jquery',
       'jQuery': 'jquery',
       'window.jQuery': 'jquery',
-      'moment': 'moment'
+      'moment': 'moment',
     }),
     new webpack.optimize.CommonsChunkPlugin({
       name: 'vendor',
@@ -29,45 +27,44 @@ module.exports = {
         return module.context
           && module.context.indexOf('node_modules') !== -1
           && module.context.indexOf('bootswatch') === -1;
-      }
+      },
     }),
-    new ExtractTextPlugin("[name].css"),
+    new ExtractTextPlugin('[name].css'),
     new CopyWebpackPlugin([
-        { from: 'node_modules/swagger-ui-dist', to: 'swagger' },
-        { from: 'src/image', to: 'image' }
-    ])
-    // new VisualizerPlugin()
-    // new BundleAnalyzerPlugin({openAnalyzer: false})
+        {from: 'node_modules/swagger-ui-dist', to: 'swagger'},
+        {from: 'src/image', to: 'image'},
+    ]),
   ],
   resolve: {
     symlinks: false,
     alias: {
       'datatables': 'datatables.net',
-      'datatables-light-columnfilter$': 'datatables-light-columnfilter/dist/dataTables.lightColumnFilter.js'
+      'datatables-light-columnfilter$':
+      'datatables-light-columnfilter/dist/dataTables.lightColumnFilter.js',
     },
     modules: [
       path.resolve(__dirname, 'node_modules'),
       path.resolve(__dirname, 'node_modules', '@bower_components'),
-      'node_modules'
-    ]
+      'node_modules',
+    ],
   },
   module: {
     rules: [
       {
         test: /\.html$/,
-        use: ['ng-cache-loader?prefix=[dir]']
+        use: ['ng-cache-loader?prefix=[dir]'],
       },
       {
         test: /\.css$/,
         use: ExtractTextPlugin.extract({
           fallback: 'style-loader',
-          use: 'css-loader?sourceMap'
-        })
+          use: 'css-loader?sourceMap',
+        }),
       },
       {
         test: /\.(eot|svg|ttf|woff|woff2|gif|png)$/,
-        use: ['url-loader']
-      }
-    ]
-  }
+        use: ['url-loader'],
+      },
+    ],
+  },
 };

--- a/brew_view/static/webpack.dev.js
+++ b/brew_view/static/webpack.dev.js
@@ -13,7 +13,7 @@ module.exports = merge(common, {
     stats: 'minimal',
     proxy: [{
       context: ['/api', '/config', '/version'],
-      target: 'http://localhost:2337/'
-    }]
-  }
+      target: 'http://localhost:2337/',
+    }],
+  },
 });

--- a/brew_view/static/webpack.prod.js
+++ b/brew_view/static/webpack.prod.js
@@ -4,12 +4,26 @@ const common = require('./webpack.common.js');
 const OptimizeCssAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 
 module.exports = merge(common, {
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        exclude: /(node_modules)/,
+        use: {
+          loader: 'babel-loader',
+          options: {
+            presets: ['env'],
+          },
+        },
+      },
+    ],
+  },
   devtool: 'source-map',
   plugins: [
     new webpack.optimize.UglifyJsPlugin({
       sourceMap: true,
-      mangle: true
+      mangle: true,
     }),
-    new OptimizeCssAssetsPlugin()
-  ]
+    new OptimizeCssAssetsPlugin(),
+  ],
 });

--- a/brew_view/static/yarn.lock
+++ b/brew_view/static/yarn.lock
@@ -413,6 +413,373 @@ babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
     esutils "^2.0.2"
     js-tokens "^3.0.2"
 
+babel-core@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.26.0.tgz#af32f78b31a6fcef119c87b0fd8d9753f03a0bb8"
+  dependencies:
+    babel-code-frame "^6.26.0"
+    babel-generator "^6.26.0"
+    babel-helpers "^6.24.1"
+    babel-messages "^6.23.0"
+    babel-register "^6.26.0"
+    babel-runtime "^6.26.0"
+    babel-template "^6.26.0"
+    babel-traverse "^6.26.0"
+    babel-types "^6.26.0"
+    babylon "^6.18.0"
+    convert-source-map "^1.5.0"
+    debug "^2.6.8"
+    json5 "^0.5.1"
+    lodash "^4.17.4"
+    minimatch "^3.0.4"
+    path-is-absolute "^1.0.1"
+    private "^0.1.7"
+    slash "^1.0.0"
+    source-map "^0.5.6"
+
+babel-generator@^6.26.0:
+  version "6.26.1"
+  resolved "https://registry.yarnpkg.com/babel-generator/-/babel-generator-6.26.1.tgz#1844408d3b8f0d35a404ea7ac180f087a601bd90"
+  dependencies:
+    babel-messages "^6.23.0"
+    babel-runtime "^6.26.0"
+    babel-types "^6.26.0"
+    detect-indent "^4.0.0"
+    jsesc "^1.3.0"
+    lodash "^4.17.4"
+    source-map "^0.5.7"
+    trim-right "^1.0.1"
+
+babel-helper-builder-binary-assignment-operator-visitor@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz#cce4517ada356f4220bcae8a02c2b346f9a56664"
+  dependencies:
+    babel-helper-explode-assignable-expression "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-types "^6.24.1"
+
+babel-helper-call-delegate@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz#ece6aacddc76e41c3461f88bfc575bd0daa2df8d"
+  dependencies:
+    babel-helper-hoist-variables "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-traverse "^6.24.1"
+    babel-types "^6.24.1"
+
+babel-helper-define-map@^6.24.1:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz#a5f56dab41a25f97ecb498c7ebaca9819f95be5f"
+  dependencies:
+    babel-helper-function-name "^6.24.1"
+    babel-runtime "^6.26.0"
+    babel-types "^6.26.0"
+    lodash "^4.17.4"
+
+babel-helper-explode-assignable-expression@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz#f25b82cf7dc10433c55f70592d5746400ac22caa"
+  dependencies:
+    babel-runtime "^6.22.0"
+    babel-traverse "^6.24.1"
+    babel-types "^6.24.1"
+
+babel-helper-function-name@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz#d3475b8c03ed98242a25b48351ab18399d3580a9"
+  dependencies:
+    babel-helper-get-function-arity "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+    babel-traverse "^6.24.1"
+    babel-types "^6.24.1"
+
+babel-helper-get-function-arity@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz#8f7782aa93407c41d3aa50908f89b031b1b6853d"
+  dependencies:
+    babel-runtime "^6.22.0"
+    babel-types "^6.24.1"
+
+babel-helper-hoist-variables@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz#1ecb27689c9d25513eadbc9914a73f5408be7a76"
+  dependencies:
+    babel-runtime "^6.22.0"
+    babel-types "^6.24.1"
+
+babel-helper-optimise-call-expression@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz#f7a13427ba9f73f8f4fa993c54a97882d1244257"
+  dependencies:
+    babel-runtime "^6.22.0"
+    babel-types "^6.24.1"
+
+babel-helper-regex@^6.24.1:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz#325c59f902f82f24b74faceed0363954f6495e72"
+  dependencies:
+    babel-runtime "^6.26.0"
+    babel-types "^6.26.0"
+    lodash "^4.17.4"
+
+babel-helper-remap-async-to-generator@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz#5ec581827ad723fecdd381f1c928390676e4551b"
+  dependencies:
+    babel-helper-function-name "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+    babel-traverse "^6.24.1"
+    babel-types "^6.24.1"
+
+babel-helper-replace-supers@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz#bf6dbfe43938d17369a213ca8a8bf74b6a90ab1a"
+  dependencies:
+    babel-helper-optimise-call-expression "^6.24.1"
+    babel-messages "^6.23.0"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+    babel-traverse "^6.24.1"
+    babel-types "^6.24.1"
+
+babel-helpers@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-helpers/-/babel-helpers-6.24.1.tgz#3471de9caec388e5c850e597e58a26ddf37602b2"
+  dependencies:
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+
+babel-loader@^7.1.2:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-7.1.2.tgz#f6cbe122710f1aa2af4d881c6d5b54358ca24126"
+  dependencies:
+    find-cache-dir "^1.0.0"
+    loader-utils "^1.0.2"
+    mkdirp "^0.5.1"
+
+babel-messages@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-messages/-/babel-messages-6.23.0.tgz#f3cdf4703858035b2a2951c6ec5edf6c62f2630e"
+  dependencies:
+    babel-runtime "^6.22.0"
+
+babel-plugin-check-es2015-constants@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz#35157b101426fd2ffd3da3f75c7d1e91835bbf8a"
+  dependencies:
+    babel-runtime "^6.22.0"
+
+babel-plugin-syntax-async-functions@^6.8.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#cad9cad1191b5ad634bf30ae0872391e0647be95"
+
+babel-plugin-syntax-exponentiation-operator@^6.8.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz#9ee7e8337290da95288201a6a57f4170317830de"
+
+babel-plugin-syntax-trailing-function-commas@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz#ba0360937f8d06e40180a43fe0d5616fff532cf3"
+
+babel-plugin-transform-async-to-generator@^6.22.0:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz#6536e378aff6cb1d5517ac0e40eb3e9fc8d08761"
+  dependencies:
+    babel-helper-remap-async-to-generator "^6.24.1"
+    babel-plugin-syntax-async-functions "^6.8.0"
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-es2015-arrow-functions@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz#452692cb711d5f79dc7f85e440ce41b9f244d221"
+  dependencies:
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-es2015-block-scoped-functions@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz#bbc51b49f964d70cb8d8e0b94e820246ce3a6141"
+  dependencies:
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-es2015-block-scoping@^6.23.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz#d70f5299c1308d05c12f463813b0a09e73b1895f"
+  dependencies:
+    babel-runtime "^6.26.0"
+    babel-template "^6.26.0"
+    babel-traverse "^6.26.0"
+    babel-types "^6.26.0"
+    lodash "^4.17.4"
+
+babel-plugin-transform-es2015-classes@^6.23.0:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz#5a4c58a50c9c9461e564b4b2a3bfabc97a2584db"
+  dependencies:
+    babel-helper-define-map "^6.24.1"
+    babel-helper-function-name "^6.24.1"
+    babel-helper-optimise-call-expression "^6.24.1"
+    babel-helper-replace-supers "^6.24.1"
+    babel-messages "^6.23.0"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+    babel-traverse "^6.24.1"
+    babel-types "^6.24.1"
+
+babel-plugin-transform-es2015-computed-properties@^6.22.0:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz#6fe2a8d16895d5634f4cd999b6d3480a308159b3"
+  dependencies:
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+
+babel-plugin-transform-es2015-destructuring@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz#997bb1f1ab967f682d2b0876fe358d60e765c56d"
+  dependencies:
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-es2015-duplicate-keys@^6.22.0:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz#73eb3d310ca969e3ef9ec91c53741a6f1576423e"
+  dependencies:
+    babel-runtime "^6.22.0"
+    babel-types "^6.24.1"
+
+babel-plugin-transform-es2015-for-of@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz#f47c95b2b613df1d3ecc2fdb7573623c75248691"
+  dependencies:
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-es2015-function-name@^6.22.0:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz#834c89853bc36b1af0f3a4c5dbaa94fd8eacaa8b"
+  dependencies:
+    babel-helper-function-name "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-types "^6.24.1"
+
+babel-plugin-transform-es2015-literals@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz#4f54a02d6cd66cf915280019a31d31925377ca2e"
+  dependencies:
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-es2015-modules-amd@^6.22.0, babel-plugin-transform-es2015-modules-amd@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz#3b3e54017239842d6d19c3011c4bd2f00a00d154"
+  dependencies:
+    babel-plugin-transform-es2015-modules-commonjs "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+
+babel-plugin-transform-es2015-modules-commonjs@^6.23.0, babel-plugin-transform-es2015-modules-commonjs@^6.24.1:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz#0d8394029b7dc6abe1a97ef181e00758dd2e5d8a"
+  dependencies:
+    babel-plugin-transform-strict-mode "^6.24.1"
+    babel-runtime "^6.26.0"
+    babel-template "^6.26.0"
+    babel-types "^6.26.0"
+
+babel-plugin-transform-es2015-modules-systemjs@^6.23.0:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz#ff89a142b9119a906195f5f106ecf305d9407d23"
+  dependencies:
+    babel-helper-hoist-variables "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+
+babel-plugin-transform-es2015-modules-umd@^6.23.0:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz#ac997e6285cd18ed6176adb607d602344ad38468"
+  dependencies:
+    babel-plugin-transform-es2015-modules-amd "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+
+babel-plugin-transform-es2015-object-super@^6.22.0:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz#24cef69ae21cb83a7f8603dad021f572eb278f8d"
+  dependencies:
+    babel-helper-replace-supers "^6.24.1"
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-es2015-parameters@^6.23.0:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz#57ac351ab49caf14a97cd13b09f66fdf0a625f2b"
+  dependencies:
+    babel-helper-call-delegate "^6.24.1"
+    babel-helper-get-function-arity "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+    babel-traverse "^6.24.1"
+    babel-types "^6.24.1"
+
+babel-plugin-transform-es2015-shorthand-properties@^6.22.0:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz#24f875d6721c87661bbd99a4622e51f14de38aa0"
+  dependencies:
+    babel-runtime "^6.22.0"
+    babel-types "^6.24.1"
+
+babel-plugin-transform-es2015-spread@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz#d6d68a99f89aedc4536c81a542e8dd9f1746f8d1"
+  dependencies:
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-es2015-sticky-regex@^6.22.0:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz#00c1cdb1aca71112cdf0cf6126c2ed6b457ccdbc"
+  dependencies:
+    babel-helper-regex "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-types "^6.24.1"
+
+babel-plugin-transform-es2015-template-literals@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz#a84b3450f7e9f8f1f6839d6d687da84bb1236d8d"
+  dependencies:
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-es2015-typeof-symbol@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz#dec09f1cddff94b52ac73d505c84df59dcceb372"
+  dependencies:
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-es2015-unicode-regex@^6.22.0:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz#d38b12f42ea7323f729387f18a7c5ae1faeb35e9"
+  dependencies:
+    babel-helper-regex "^6.24.1"
+    babel-runtime "^6.22.0"
+    regexpu-core "^2.0.0"
+
+babel-plugin-transform-exponentiation-operator@^6.22.0:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz#2ab0c9c7f3098fa48907772bb813fe41e8de3a0e"
+  dependencies:
+    babel-helper-builder-binary-assignment-operator-visitor "^6.24.1"
+    babel-plugin-syntax-exponentiation-operator "^6.8.0"
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-regenerator@^6.22.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz#e0703696fbde27f0a3efcacf8b4dca2f7b3a8f2f"
+  dependencies:
+    regenerator-transform "^0.10.0"
+
+babel-plugin-transform-strict-mode@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz#d5faf7aa578a65bbe591cf5edae04a0c67020758"
+  dependencies:
+    babel-runtime "^6.22.0"
+    babel-types "^6.24.1"
+
 babel-polyfill@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.26.0.tgz#379937abc67d7895970adc621f284cd966cf2153"
@@ -428,12 +795,96 @@ babel-polyfill@^7.0.0-beta.2:
     core-js "^2.4.0"
     regenerator-runtime "^0.11.0"
 
-babel-runtime@^6.26.0:
+babel-preset-env@^1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/babel-preset-env/-/babel-preset-env-1.6.1.tgz#a18b564cc9b9afdf4aae57ae3c1b0d99188e6f48"
+  dependencies:
+    babel-plugin-check-es2015-constants "^6.22.0"
+    babel-plugin-syntax-trailing-function-commas "^6.22.0"
+    babel-plugin-transform-async-to-generator "^6.22.0"
+    babel-plugin-transform-es2015-arrow-functions "^6.22.0"
+    babel-plugin-transform-es2015-block-scoped-functions "^6.22.0"
+    babel-plugin-transform-es2015-block-scoping "^6.23.0"
+    babel-plugin-transform-es2015-classes "^6.23.0"
+    babel-plugin-transform-es2015-computed-properties "^6.22.0"
+    babel-plugin-transform-es2015-destructuring "^6.23.0"
+    babel-plugin-transform-es2015-duplicate-keys "^6.22.0"
+    babel-plugin-transform-es2015-for-of "^6.23.0"
+    babel-plugin-transform-es2015-function-name "^6.22.0"
+    babel-plugin-transform-es2015-literals "^6.22.0"
+    babel-plugin-transform-es2015-modules-amd "^6.22.0"
+    babel-plugin-transform-es2015-modules-commonjs "^6.23.0"
+    babel-plugin-transform-es2015-modules-systemjs "^6.23.0"
+    babel-plugin-transform-es2015-modules-umd "^6.23.0"
+    babel-plugin-transform-es2015-object-super "^6.22.0"
+    babel-plugin-transform-es2015-parameters "^6.23.0"
+    babel-plugin-transform-es2015-shorthand-properties "^6.22.0"
+    babel-plugin-transform-es2015-spread "^6.22.0"
+    babel-plugin-transform-es2015-sticky-regex "^6.22.0"
+    babel-plugin-transform-es2015-template-literals "^6.22.0"
+    babel-plugin-transform-es2015-typeof-symbol "^6.23.0"
+    babel-plugin-transform-es2015-unicode-regex "^6.22.0"
+    babel-plugin-transform-exponentiation-operator "^6.22.0"
+    babel-plugin-transform-regenerator "^6.22.0"
+    browserslist "^2.1.2"
+    invariant "^2.2.2"
+    semver "^5.3.0"
+
+babel-register@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-register/-/babel-register-6.26.0.tgz#6ed021173e2fcb486d7acb45c6009a856f647071"
+  dependencies:
+    babel-core "^6.26.0"
+    babel-runtime "^6.26.0"
+    core-js "^2.5.0"
+    home-or-tmp "^2.0.0"
+    lodash "^4.17.4"
+    mkdirp "^0.5.1"
+    source-map-support "^0.4.15"
+
+babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   dependencies:
     core-js "^2.4.0"
     regenerator-runtime "^0.11.0"
+
+babel-template@^6.24.1, babel-template@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.26.0.tgz#de03e2d16396b069f46dd9fff8521fb1a0e35e02"
+  dependencies:
+    babel-runtime "^6.26.0"
+    babel-traverse "^6.26.0"
+    babel-types "^6.26.0"
+    babylon "^6.18.0"
+    lodash "^4.17.4"
+
+babel-traverse@^6.24.1, babel-traverse@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.26.0.tgz#46a9cbd7edcc62c8e5c064e2d2d8d0f4035766ee"
+  dependencies:
+    babel-code-frame "^6.26.0"
+    babel-messages "^6.23.0"
+    babel-runtime "^6.26.0"
+    babel-types "^6.26.0"
+    babylon "^6.18.0"
+    debug "^2.6.8"
+    globals "^9.18.0"
+    invariant "^2.2.2"
+    lodash "^4.17.4"
+
+babel-types@^6.19.0, babel-types@^6.24.1, babel-types@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.26.0.tgz#a3b073f94ab49eb6fa55cd65227a334380632497"
+  dependencies:
+    babel-runtime "^6.26.0"
+    esutils "^2.0.2"
+    lodash "^4.17.4"
+    to-fast-properties "^1.0.3"
+
+babylon@^6.18.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
 
 backo2@1.0.2:
   version "1.0.2"
@@ -727,6 +1178,13 @@ browserslist@^1.3.6, browserslist@^1.5.2, browserslist@^1.7.6:
     caniuse-db "^1.0.30000639"
     electron-to-chromium "^1.2.7"
 
+browserslist@^2.1.2:
+  version "2.11.3"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-2.11.3.tgz#fe36167aed1bbcde4827ebfe71347a2cc70b99b2"
+  dependencies:
+    caniuse-lite "^1.0.30000792"
+    electron-to-chromium "^1.3.30"
+
 buffer-indexof@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-indexof/-/buffer-indexof-1.1.1.tgz#52fabcc6a606d1a00302802648ef68f639da268c"
@@ -843,6 +1301,10 @@ caniuse-api@^1.5.2:
 caniuse-db@^1.0.30000529, caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
   version "1.0.30000804"
   resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000804.tgz#84feb42018fc64cf6aff6371e43115f292c00179"
+
+caniuse-lite@^1.0.30000792:
+  version "1.0.30000808"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000808.tgz#7d759b5518529ea08b6705a19e70dbf401628ffc"
 
 capture-stack-trace@^1.0.0:
   version "1.0.0"
@@ -1206,6 +1668,10 @@ content-disposition@0.5.2:
 content-type@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
+
+convert-source-map@^1.5.0:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.1.tgz#b8278097b9bc229365de5c62cf5fcaed8b5599e5"
 
 cookie-signature@1.0.6:
   version "1.0.6"
@@ -1585,6 +2051,12 @@ destroy@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
 
+detect-indent@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-4.0.0.tgz#f76d064352cdf43a1cb6ce619c4ee3a9475de208"
+  dependencies:
+    repeating "^2.0.0"
+
 detect-libc@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
@@ -1708,7 +2180,7 @@ ejs@^2.5.7:
   version "2.5.7"
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.5.7.tgz#cc872c168880ae3c7189762fd5ffc00896c9518a"
 
-electron-to-chromium@^1.2.7:
+electron-to-chromium@^1.2.7, electron-to-chromium@^1.3.30:
   version "1.3.33"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.33.tgz#bf00703d62a7c65238136578c352d6c5c042a545"
 
@@ -2612,6 +3084,10 @@ globals@^11.0.1:
   version "11.3.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.3.0.tgz#e04fdb7b9796d8adac9c8f64c14837b2313378b0"
 
+globals@^9.18.0:
+  version "9.18.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
+
 globby@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/globby/-/globby-5.0.0.tgz#ebd84667ca0dbb330b99bcfc68eac2bc54370e0d"
@@ -2805,6 +3281,13 @@ hmac-drbg@^1.0.0:
 hoek@2.x.x:
   version "2.16.3"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
+
+home-or-tmp@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/home-or-tmp/-/home-or-tmp-2.0.0.tgz#e36c3f2d2cae7d746a857e38d18d5f32a7882db8"
+  dependencies:
+    os-homedir "^1.0.0"
+    os-tmpdir "^1.0.1"
 
 hosted-git-info@^2.1.4:
   version "2.5.0"
@@ -3001,6 +3484,12 @@ interpret@^1.0.0:
 intersect@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/intersect/-/intersect-1.0.1.tgz#332650e10854d8c0ac58c192bdc27a8bf7e7a30c"
+
+invariant@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.2.tgz#9e1f56ac0acdb6bf303306f338be3b204ae60360"
+  dependencies:
+    loose-envify "^1.0.0"
 
 invert-kv@^1.0.0:
   version "1.0.0"
@@ -3361,6 +3850,10 @@ jsbn@~0.1.0:
 jsesc@^0.5.0, jsesc@~0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
+
+jsesc@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-1.3.0.tgz#46c3fec8c1892b12b0833db9bc7622176dbab34b"
 
 json-loader@^0.5.4:
   version "0.5.7"
@@ -4289,7 +4782,7 @@ os-locale@^2.0.0:
     lcid "^1.0.0"
     mem "^1.1.0"
 
-os-tmpdir@^1.0.0, os-tmpdir@~1.0.1, os-tmpdir@~1.0.2:
+os-tmpdir@^1.0.0, os-tmpdir@^1.0.1, os-tmpdir@~1.0.1, os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
 
@@ -4420,7 +4913,7 @@ path-exists@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
 
-path-is-absolute@^1.0.0:
+path-is-absolute@^1.0.0, path-is-absolute@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
 
@@ -4784,7 +5277,7 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-private@^0.1.6, private@~0.1.5:
+private@^0.1.6, private@^0.1.7, private@~0.1.5:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
 
@@ -5075,6 +5568,14 @@ regenerator-runtime@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
 
+regenerator-transform@^0.10.0:
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/regenerator-transform/-/regenerator-transform-0.10.1.tgz#1e4996837231da8b7f3cf4114d71b5691a0680dd"
+  dependencies:
+    babel-runtime "^6.18.0"
+    babel-types "^6.19.0"
+    private "^0.1.6"
+
 regex-cache@^0.4.2:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/regex-cache/-/regex-cache-0.4.4.tgz#75bdc58a2a1496cec48a12835bc54c8d562336dd"
@@ -5090,6 +5591,14 @@ regex-not@^1.0.0:
 regexpu-core@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-1.0.0.tgz#86a763f58ee4d7c2f6b102e4764050de7ed90c6b"
+  dependencies:
+    regenerate "^1.2.1"
+    regjsgen "^0.2.0"
+    regjsparser "^0.1.4"
+
+regexpu-core@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-2.0.0.tgz#49d038837b8dcf8bfa5b9a42139938e6ea2ae240"
   dependencies:
     regenerate "^1.2.1"
     regjsgen "^0.2.0"
@@ -5565,11 +6074,17 @@ source-map-resolve@^0.5.0:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
+source-map-support@^0.4.15:
+  version "0.4.18"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.18.tgz#0286a6de8be42641338594e97ccea75f0a2c585f"
+  dependencies:
+    source-map "^0.5.6"
+
 source-map-url@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
 
-source-map@0.5.x, source-map@^0.5.1, source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.0, source-map@~0.5.1:
+source-map@0.5.x, source-map@^0.5.1, source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7, source-map@~0.5.0, source-map@~0.5.1:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
 
@@ -5922,6 +6437,10 @@ to-arraybuffer@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz#7d229b1fcc637e466ca081180836a7aabff83f43"
 
+to-fast-properties@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
+
 to-object-path@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/to-object-path/-/to-object-path-0.3.0.tgz#297588b7b0e7e0ac08e04e672f85c1f4999e17af"
@@ -5956,6 +6475,10 @@ traverse@0.6.x:
 trim-newlines@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"
+
+trim-right@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
 
 tryer@^1.0.0:
   version "1.0.0"

--- a/brew_view/static/yarn.lock
+++ b/brew_view/static/yarn.lock
@@ -52,11 +52,21 @@ acorn-dynamic-import@^2.0.0:
   dependencies:
     acorn "^4.0.3"
 
+acorn-jsx@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-3.0.1.tgz#afdf9488fb1ecefc8348f6fb22f464e32a58b36b"
+  dependencies:
+    acorn "^3.0.4"
+
+acorn@^3.0.4:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
+
 acorn@^4.0.3:
   version "4.0.13"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.13.tgz#105495ae5361d697bd195c825192e1ad7f253787"
 
-acorn@^5.0.0, acorn@^5.2.1, acorn@^5.3.0:
+acorn@^5.0.0, acorn@^5.2.1, acorn@^5.3.0, acorn@^5.4.0:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.4.1.tgz#fdc58d9d17f4a4e98d102ded826a9b9759125102"
 
@@ -64,7 +74,7 @@ after@0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/after/-/after-0.8.2.tgz#fedb394f9f0e02aa9768e702bda23b505fae7e1f"
 
-ajv-keywords@^2.0.0:
+ajv-keywords@^2.0.0, ajv-keywords@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-2.1.1.tgz#617997fc5f60576894c435f940d819e135b80762"
 
@@ -75,7 +85,7 @@ ajv@^4.9.1:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
 
-ajv@^5.0.0, ajv@^5.1.5:
+ajv@^5.0.0, ajv@^5.1.5, ajv@^5.2.3, ajv@^5.3.0:
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965"
   dependencies:
@@ -183,6 +193,10 @@ ansi-align@^2.0.0:
   resolved "https://registry.yarnpkg.com/ansi-align/-/ansi-align-2.0.0.tgz#c36aeccba563b89ceb556f3690f0b1d9e3547f7f"
   dependencies:
     string-width "^2.0.0"
+
+ansi-escapes@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.0.0.tgz#ec3e8b4e9f8064fc02c3ac9b65f1c275bda8ef92"
 
 ansi-html@0.0.7:
   version "0.0.7"
@@ -300,7 +314,7 @@ arraybuffer.slice@0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz#f33b2159f0532a3f3107a272c0ccfbd1ad2979ca"
 
-arrify@^1.0.1:
+arrify@^1.0.0, arrify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
 
@@ -391,7 +405,7 @@ aws4@^1.2.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
 
-babel-code-frame@^6.26.0:
+babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
   dependencies:
@@ -773,9 +787,19 @@ cache-base@^1.0.1:
     union-value "^1.0.0"
     unset-value "^1.0.0"
 
+caller-path@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/caller-path/-/caller-path-0.1.0.tgz#94085ef63581ecd3daa92444a8fe94e82577751f"
+  dependencies:
+    callsites "^0.2.0"
+
 callsite@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/callsite/-/callsite-1.0.0.tgz#280398e5d664bd74038b6f0905153e6e8af1bc20"
+
+callsites@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/callsites/-/callsites-0.2.0.tgz#afab96262910a7f33c19a5775825c69f34e350ca"
 
 camel-case@3.0.x:
   version "3.0.0"
@@ -856,13 +880,17 @@ chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0.1, chalk@^2.3.0:
+chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.0.tgz#b5ea48efc9c1793dccc9b4767c93914d3f2d52ba"
   dependencies:
     ansi-styles "^3.1.0"
     escape-string-regexp "^1.0.5"
     supports-color "^4.0.0"
+
+chardet@^0.4.0:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
 
 charm@0.1.x:
   version "0.1.2"
@@ -920,6 +948,10 @@ cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
+circular-json@^0.3.1:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.3.tgz#815c99ea84f6809529d2f45791bdf82711352d66"
+
 clap@^1.0.9:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/clap/-/clap-1.2.3.tgz#4f36745b32008492557f46412d66d50cb99bce51"
@@ -944,6 +976,16 @@ clean-css@4.1.x:
 cli-boxes@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-1.0.0.tgz#4fa917c3e59c94a004cd61f8ee509da651687143"
+
+cli-cursor@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"
+  dependencies:
+    restore-cursor "^2.0.0"
+
+cli-width@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.0.tgz#ff19ede8a9a5e579324147b0c11f0fbcbabed639"
 
 cliui@^2.1.0:
   version "2.1.0"
@@ -1111,7 +1153,7 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-concat-stream@^1.5.0:
+concat-stream@^1.5.0, concat-stream@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.0.tgz#0aac662fd52be78964d5532f694784e70110acf7"
   dependencies:
@@ -1246,7 +1288,7 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-cross-spawn@^5.0.1:
+cross-spawn@^5.0.1, cross-spawn@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
   dependencies:
@@ -1493,6 +1535,18 @@ defined@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/defined/-/defined-1.0.0.tgz#c98d9bcef75674188e110969151199e39b1fa693"
 
+del@^2.0.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/del/-/del-2.2.2.tgz#c12c981d067846c84bcaf862cff930d907ffd1a8"
+  dependencies:
+    globby "^5.0.0"
+    is-path-cwd "^1.0.0"
+    is-path-in-cwd "^1.0.0"
+    object-assign "^4.0.1"
+    pify "^2.0.0"
+    pinkie-promise "^2.0.0"
+    rimraf "^2.2.8"
+
 del@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/del/-/del-3.0.0.tgz#53ecf699ffcbcb39637691ab13baf160819766e5"
@@ -1597,6 +1651,12 @@ dns-txt@^2.0.2:
   resolved "https://registry.yarnpkg.com/dns-txt/-/dns-txt-2.0.2.tgz#b91d806f5d27188e4ab3e7d107d881a1cc4642b6"
   dependencies:
     buffer-indexof "^1.0.0"
+
+doctrine@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
+  dependencies:
+    esutils "^2.0.2"
 
 dom-serialize@^2.2.0:
   version "2.2.1"
@@ -1867,6 +1927,80 @@ escope@^3.6.0:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
+eslint-config-google@^0.9.1:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/eslint-config-google/-/eslint-config-google-0.9.1.tgz#83353c3dba05f72bb123169a4094f4ff120391eb"
+
+eslint-loader@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/eslint-loader/-/eslint-loader-1.9.0.tgz#7e1be9feddca328d3dcfaef1ad49d5beffe83a13"
+  dependencies:
+    loader-fs-cache "^1.0.0"
+    loader-utils "^1.0.2"
+    object-assign "^4.0.1"
+    object-hash "^1.1.4"
+    rimraf "^2.6.1"
+
+eslint-scope@^3.7.1:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-3.7.1.tgz#3d63c3edfda02e06e01a452ad88caacc7cdcb6e8"
+  dependencies:
+    esrecurse "^4.1.0"
+    estraverse "^4.1.1"
+
+eslint-visitor-keys@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
+
+eslint@^4.17.0:
+  version "4.17.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.17.0.tgz#dc24bb51ede48df629be7031c71d9dc0ee4f3ddf"
+  dependencies:
+    ajv "^5.3.0"
+    babel-code-frame "^6.22.0"
+    chalk "^2.1.0"
+    concat-stream "^1.6.0"
+    cross-spawn "^5.1.0"
+    debug "^3.1.0"
+    doctrine "^2.1.0"
+    eslint-scope "^3.7.1"
+    eslint-visitor-keys "^1.0.0"
+    espree "^3.5.2"
+    esquery "^1.0.0"
+    esutils "^2.0.2"
+    file-entry-cache "^2.0.0"
+    functional-red-black-tree "^1.0.1"
+    glob "^7.1.2"
+    globals "^11.0.1"
+    ignore "^3.3.3"
+    imurmurhash "^0.1.4"
+    inquirer "^3.0.6"
+    is-resolvable "^1.0.0"
+    js-yaml "^3.9.1"
+    json-stable-stringify-without-jsonify "^1.0.1"
+    levn "^0.3.0"
+    lodash "^4.17.4"
+    minimatch "^3.0.2"
+    mkdirp "^0.5.1"
+    natural-compare "^1.4.0"
+    optionator "^0.8.2"
+    path-is-inside "^1.0.2"
+    pluralize "^7.0.0"
+    progress "^2.0.0"
+    require-uncached "^1.0.3"
+    semver "^5.3.0"
+    strip-ansi "^4.0.0"
+    strip-json-comments "~2.0.1"
+    table "^4.0.1"
+    text-table "~0.2.0"
+
+espree@^3.5.2:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.3.tgz#931e0af64e7fbbed26b050a29daad1fc64799fa6"
+  dependencies:
+    acorn "^5.4.0"
+    acorn-jsx "^3.0.0"
+
 esprima-fb@^15001.1.0-dev-harmony-fb:
   version "15001.1.0-dev-harmony-fb"
   resolved "https://registry.yarnpkg.com/esprima-fb/-/esprima-fb-15001.1.0-dev-harmony-fb.tgz#30a947303c6b8d5e955bee2b99b1d233206a6901"
@@ -1883,6 +2017,12 @@ esprima@~3.1.0:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
 
+esquery@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.0.0.tgz#cfba8b57d7fba93f17298a8a006a04cda13d80fa"
+  dependencies:
+    estraverse "^4.0.0"
+
 esrecurse@^4.1.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.2.0.tgz#fa9568d98d3823f9a41d91e902dcab9ea6e5b163"
@@ -1894,7 +2034,7 @@ estraverse@^1.9.1:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-1.9.3.tgz#af67f2dc922582415950926091a4005d29c9bb44"
 
-estraverse@^4.1.0, estraverse@^4.1.1:
+estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
 
@@ -2068,6 +2208,14 @@ extend@^3.0.0, extend@~3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
 
+external-editor@^2.0.4:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-2.1.0.tgz#3d026a21b7f95b5726387d4200ac160d372c3b48"
+  dependencies:
+    chardet "^0.4.0"
+    iconv-lite "^0.4.17"
+    tmp "^0.0.33"
+
 extglob@^0.3.1:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/extglob/-/extglob-0.3.2.tgz#2e18ff3d2f49ab2765cec9023f011daa8d8349a1"
@@ -2142,6 +2290,19 @@ fbjs@^0.6.1:
     ua-parser-js "^0.7.9"
     whatwg-fetch "^0.9.0"
 
+figures@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/figures/-/figures-2.0.0.tgz#3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962"
+  dependencies:
+    escape-string-regexp "^1.0.5"
+
+file-entry-cache@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-2.0.0.tgz#c392990c3e684783d838b8c84a45d8a048458361"
+  dependencies:
+    flat-cache "^1.2.1"
+    object-assign "^4.0.1"
+
 file-loader@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-1.1.6.tgz#7b9a8f2c58f00a77fddf49e940f7ac978a3ea0e8"
@@ -2200,6 +2361,14 @@ finalhandler@1.1.0:
     statuses "~1.3.1"
     unpipe "~1.0.0"
 
+find-cache-dir@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-0.1.1.tgz#c8defae57c8a52a8a784f9e31c57c742e993a0b9"
+  dependencies:
+    commondir "^1.0.1"
+    mkdirp "^0.5.1"
+    pkg-dir "^1.0.0"
+
 find-cache-dir@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-1.0.0.tgz#9288e3e9e3cc3748717d39eade17cf71fc30ee6f"
@@ -2220,6 +2389,15 @@ find-up@^2.0.0, find-up@^2.1.0:
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
   dependencies:
     locate-path "^2.0.0"
+
+flat-cache@^1.2.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-1.3.0.tgz#d3030b32b38154f4e3b7e9c709f490f7ef97c481"
+  dependencies:
+    circular-json "^0.3.1"
+    del "^2.0.2"
+    graceful-fs "^4.1.2"
+    write "^0.2.1"
 
 flatten@^1.0.2:
   version "1.0.2"
@@ -2340,6 +2518,10 @@ function-bind@^1.0.2, function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
 
+functional-red-black-tree@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
+
 gauge@~2.7.3:
   version "2.7.4"
   resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"
@@ -2425,6 +2607,21 @@ global-dirs@^0.1.0:
   resolved "https://registry.yarnpkg.com/global-dirs/-/global-dirs-0.1.1.tgz#b319c0dd4607f353f3be9cca4c72fc148c49f445"
   dependencies:
     ini "^1.3.4"
+
+globals@^11.0.1:
+  version "11.3.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-11.3.0.tgz#e04fdb7b9796d8adac9c8f64c14837b2313378b0"
+
+globby@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-5.0.0.tgz#ebd84667ca0dbb330b99bcfc68eac2bc54370e0d"
+  dependencies:
+    array-union "^1.0.1"
+    arrify "^1.0.0"
+    glob "^7.0.3"
+    object-assign "^4.0.1"
+    pify "^2.0.0"
+    pinkie-promise "^2.0.0"
 
 globby@^6.1.0:
   version "6.1.0"
@@ -2698,7 +2895,7 @@ https-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
 
-iconv-lite@0.4.19, iconv-lite@^0.4.5:
+iconv-lite@0.4.19, iconv-lite@^0.4.17, iconv-lite@^0.4.5:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
 
@@ -2720,7 +2917,7 @@ iferr@^0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/iferr/-/iferr-0.1.5.tgz#c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501"
 
-ignore@^3.3.5:
+ignore@^3.3.3, ignore@^3.3.5:
   version "3.3.7"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.7.tgz#612289bfb3c220e186a58118618d5be8c1bab021"
 
@@ -2771,6 +2968,25 @@ inherits@2.0.1:
 ini@^1.3.4, ini@~1.3.0:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
+
+inquirer@^3.0.6:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-3.3.0.tgz#9dd2f2ad765dcab1ff0443b491442a20ba227dc9"
+  dependencies:
+    ansi-escapes "^3.0.0"
+    chalk "^2.0.0"
+    cli-cursor "^2.1.0"
+    cli-width "^2.0.0"
+    external-editor "^2.0.4"
+    figures "^2.0.0"
+    lodash "^4.3.0"
+    mute-stream "0.0.7"
+    run-async "^2.2.0"
+    rx-lite "^4.0.8"
+    rx-lite-aggregates "^4.0.8"
+    string-width "^2.1.0"
+    strip-ansi "^4.0.0"
+    through "^2.3.6"
 
 internal-ip@1.2.0:
   version "1.2.0"
@@ -3003,6 +3219,10 @@ is-primitive@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-primitive/-/is-primitive-2.0.0.tgz#207bab91638499c07b2adf240a41a87210034575"
 
+is-promise@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
+
 is-redirect@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-redirect/-/is-redirect-1.0.0.tgz#1d03dded53bd8db0f30c26e4f95d36fc7c87dc24"
@@ -3012,6 +3232,10 @@ is-regex@^1.0.4:
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
   dependencies:
     has "^1.0.1"
+
+is-resolvable@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.1.0.tgz#fb18f87ce1feb925169c9a407c19318a3206ed88"
 
 is-retry-allowed@^1.0.0:
   version "1.1.0"
@@ -3116,7 +3340,7 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
-js-yaml@3.x:
+js-yaml@3.x, js-yaml@^3.9.1:
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.10.0.tgz#2e78441646bd4682e963f22b6e92823c309c62dc"
   dependencies:
@@ -3149,6 +3373,10 @@ json-schema-traverse@^0.3.0:
 json-schema@0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
+
+json-stable-stringify-without-jsonify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
 
 json-stable-stringify@^1.0.1:
   version "1.0.1"
@@ -3319,7 +3547,7 @@ lcid@^1.0.0:
   dependencies:
     invert-kv "^1.0.0"
 
-levn@~0.3.0:
+levn@^0.3.0, levn@~0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
   dependencies:
@@ -3344,6 +3572,13 @@ load-json-file@^2.0.0:
     parse-json "^2.2.0"
     pify "^2.0.0"
     strip-bom "^3.0.0"
+
+loader-fs-cache@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/loader-fs-cache/-/loader-fs-cache-1.0.1.tgz#56e0bf08bd9708b26a765b68509840c8dec9fdbc"
+  dependencies:
+    find-cache-dir "^0.1.1"
+    mkdirp "0.5.1"
 
 loader-runner@^2.3.0:
   version "2.3.0"
@@ -3393,7 +3628,7 @@ lodash@3.x, lodash@^3.8.0:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
-lodash@^4.14.0, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.5.0:
+lodash@^4.14.0, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.3.0, lodash@^4.5.0:
   version "4.17.5"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
 
@@ -3720,6 +3955,10 @@ multicast-dns@^6.0.1:
     dns-packet "^1.3.1"
     thunky "^1.0.2"
 
+mute-stream@0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
+
 nan@^2.3.0:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.8.0.tgz#ed715f3fe9de02b57a5e6252d90a96675e1f085a"
@@ -3739,6 +3978,10 @@ nanomatch@^1.2.5:
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
+
+natural-compare@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
 
 ncname@1.0.x:
   version "1.0.0"
@@ -3922,6 +4165,10 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
+object-hash@^1.1.4:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-1.2.0.tgz#e96af0e96981996a1d47f88ead8f74f1ebc4422b"
+
 object-keys@^1.0.8:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
@@ -3969,6 +4216,12 @@ once@1.x, once@^1.3.0, once@^1.3.1, once@^1.3.3, once@^1.4.0:
   dependencies:
     wrappy "1"
 
+onetime@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-2.0.1.tgz#067428230fd67443b2794b22bba528b6867962d4"
+  dependencies:
+    mimic-fn "^1.0.0"
+
 opener@^1.4.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/opener/-/opener-1.4.3.tgz#5c6da2c5d7e5831e8ffa3964950f8d6674ac90b8"
@@ -3993,7 +4246,7 @@ optimize-css-assets-webpack-plugin@^3.1.1:
     cssnano "^3.4.0"
     last-call-webpack-plugin "^2.1.2"
 
-optionator@^0.8.1:
+optionator@^0.8.1, optionator@^0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.2.tgz#364c5e409d3f4d6301d6c0b4c05bba50180aeb64"
   dependencies:
@@ -4171,7 +4424,7 @@ path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
 
-path-is-inside@^1.0.1:
+path-is-inside@^1.0.1, path-is-inside@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
 
@@ -4245,11 +4498,21 @@ pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
 
+pkg-dir@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-1.0.0.tgz#7a4b508a8d5bb2d629d447056ff4e9c9314cf3d4"
+  dependencies:
+    find-up "^1.0.0"
+
 pkg-dir@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-2.0.0.tgz#f6d5d1109e19d63edf428e0bd57e12777615334b"
   dependencies:
     find-up "^2.1.0"
+
+pluralize@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-7.0.0.tgz#298b89df8b93b0221dbf421ad2b1b1ea23fc6777"
 
 portfinder@^1.0.9:
   version "1.0.13"
@@ -4536,6 +4799,10 @@ process-nextick-args@~2.0.0:
 process@^0.11.10:
   version "0.11.10"
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
+
+progress@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
 
 promise-inflight@^1.0.1:
   version "1.0.1"
@@ -4912,6 +5179,13 @@ require-main-filename@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
 
+require-uncached@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/require-uncached/-/require-uncached-1.0.3.tgz#4e0d56d6c9662fd31e43011c4b95aa49955421d3"
+  dependencies:
+    caller-path "^0.1.0"
+    resolve-from "^1.0.0"
+
 requires-port@1.0.x, requires-port@1.x.x, requires-port@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
@@ -4921,6 +5195,10 @@ resolve-cwd@^2.0.0:
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-2.0.0.tgz#00a9f7387556e27038eae232caa372a6a59b665a"
   dependencies:
     resolve-from "^3.0.0"
+
+resolve-from@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
 
 resolve-from@^3.0.0:
   version "3.0.0"
@@ -4933,6 +5211,13 @@ resolve-url@^0.2.1:
 resolve@1.1.x:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
+
+restore-cursor@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-2.0.0.tgz#9f7ee287f82fd326d4fd162923d62129eee0dfaf"
+  dependencies:
+    onetime "^2.0.0"
+    signal-exit "^3.0.2"
 
 right-align@^0.1.1:
   version "0.1.3"
@@ -4953,11 +5238,27 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^2.0.0"
     inherits "^2.0.1"
 
+run-async@^2.2.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.3.0.tgz#0371ab4ae0bdd720d4166d7dfda64ff7a445a6c0"
+  dependencies:
+    is-promise "^2.1.0"
+
 run-queue@^1.0.0, run-queue@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/run-queue/-/run-queue-1.0.3.tgz#e848396f057d223f24386924618e25694161ec47"
   dependencies:
     aproba "^1.1.1"
+
+rx-lite-aggregates@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz#753b87a89a11c95467c4ac1626c4efc4e05c67be"
+  dependencies:
+    rx-lite "*"
+
+rx-lite@*, rx-lite@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-4.0.8.tgz#0b1e11af8bc44836f04a6407e92da42467b79444"
 
 safe-buffer@5.1.1, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
@@ -5136,6 +5437,12 @@ sinon@^4.0.1:
 slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
+
+slice-ansi@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-1.0.0.tgz#044f1a49d8842ff307aad6b505ed178bd950134d"
+  dependencies:
+    is-fullwidth-code-point "^2.0.0"
 
 snapdragon-node@^2.0.1:
   version "2.1.1"
@@ -5408,7 +5715,7 @@ string-width@^1.0.1, string-width@^1.0.2:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
-string-width@^2.0.0, string-width@^2.1.1:
+string-width@^2.0.0, string-width@^2.1.0, string-width@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
   dependencies:
@@ -5516,6 +5823,17 @@ swagger-ui-dist@^3.9.3:
   version "3.9.3"
   resolved "https://registry.yarnpkg.com/swagger-ui-dist/-/swagger-ui-dist-3.9.3.tgz#caba91e8550d7d2464a08456bd936d7c430f0dd3"
 
+table@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/table/-/table-4.0.2.tgz#a33447375391e766ad34d3486e6e2aedc84d2e36"
+  dependencies:
+    ajv "^5.2.3"
+    ajv-keywords "^2.1.0"
+    chalk "^2.1.0"
+    lodash "^4.17.4"
+    slice-ansi "1.0.0"
+    string-width "^2.1.1"
+
 tapable@^0.2.7:
   version "0.2.8"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-0.2.8.tgz#99372a5c999bf2df160afc0d74bed4f47948cd22"
@@ -5551,6 +5869,10 @@ text-encoding@^0.6.4:
   version "0.6.4"
   resolved "https://registry.yarnpkg.com/text-encoding/-/text-encoding-0.6.4.tgz#e399a982257a276dae428bb92845cb71bdc26d19"
 
+text-table@~0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
+
 through2@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.3.tgz#0004569b37c7c74ba39c43f3ced78d1ad94140be"
@@ -5558,7 +5880,7 @@ through2@^2.0.0:
     readable-stream "^2.1.5"
     xtend "~4.0.1"
 
-through@~2.3.4, through@~2.3.6:
+through@^2.3.6, through@~2.3.4, through@~2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 
@@ -5586,7 +5908,7 @@ tmp@0.0.31:
   dependencies:
     os-tmpdir "~1.0.1"
 
-tmp@0.0.x:
+tmp@0.0.x, tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
   dependencies:
@@ -6123,6 +6445,12 @@ write-file-atomic@^2.0.0:
     graceful-fs "^4.1.11"
     imurmurhash "^0.1.4"
     signal-exit "^3.0.2"
+
+write@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/write/-/write-0.2.1.tgz#5fc03828e264cea3fe91455476f7a3c566cb0757"
+  dependencies:
+    mkdirp "^0.5.1"
 
 ws@1.1.2:
   version "1.1.2"

--- a/test/unit/brew_view_test.py
+++ b/test/unit/brew_view_test.py
@@ -60,7 +60,9 @@ class BeerGardenTest(unittest.TestCase):
         self.assertIsInstance(app, Application)
 
     def test_setup_tornado_app_debug_true(self):
-        config = self.spec.load_config({'debug_mode': True, 'application_name': 'Beergarden', 'url_prefix': '/'})
+        config = self.spec.load_config({'debug_mode': True,
+                                        'application_name': 'Beergarden',
+                                        'url_prefix': '/'})
         app = bg._setup_tornado_app(config)
         self.assertTrue(app.settings.get('autoreload'))
 
@@ -72,13 +74,15 @@ class BeerGardenTest(unittest.TestCase):
 
     @patch('brew_view.ssl')
     def test_setup_ssl_context_ssl_enabled(self, ssl_mock):
-        config = self.spec.load_config({'ssl_enabled': True, 'ssl_public_key': '/path/to/public.key',
-                                            'ssl_private_key': '/path/to/private.key'})
+        config = self.spec.load_config({'ssl_enabled': True,
+                                        'ssl_public_key': '/path/to/public.key',
+                                        'ssl_private_key': '/path/to/private.key'})
         context_mock = Mock()
         ssl_mock.create_default_context.return_value = context_mock
 
         bg._setup_ssl_context(config)
-        context_mock.load_cert_chain.assert_called_with(certfile='/path/to/public.key', keyfile='/path/to/private.key')
+        context_mock.load_cert_chain.assert_called_with(certfile='/path/to/public.key',
+                                                        keyfile='/path/to/private.key')
 
     @patch('brew_view.PluginLoggingLoader')
     def test_load_plugin_logging_config(self, PluginLoggingLoaderMock):

--- a/test/unit/controllers/__init__.py
+++ b/test/unit/controllers/__init__.py
@@ -1,4 +1,4 @@
-from mock import patch, Mock
+from mock import patch
 from mongoengine import connect
 from tornado.testing import AsyncHTTPTestCase
 from yapconf import YapconfSpec

--- a/test/unit/controllers/admin_api_test.py
+++ b/test/unit/controllers/admin_api_test.py
@@ -8,7 +8,8 @@ class AdminAPITest(TestHandlerBase):
 
     def setUp(self):
         self.client_mock = MagicMock(name='client_mock')
-        self.fake_context = MagicMock(__enter__=Mock(return_value=self.client_mock), __exit__=Mock(return_value=False))
+        self.fake_context = MagicMock(__enter__=Mock(return_value=self.client_mock),
+                                      __exit__=Mock(return_value=False))
         self.future_mock = Future()
 
         super(AdminAPITest, self).setUp()
@@ -19,7 +20,8 @@ class AdminAPITest(TestHandlerBase):
         self.client_mock.rescanSystemDirectory.return_value = self.future_mock
         self.future_mock.set_result(None)
 
-        response = self.fetch('/api/v1/admin/', method='PATCH', body='{"operations": [{"operation": "rescan"}]}',
+        response = self.fetch('/api/v1/admin/', method='PATCH',
+                              body='{"operations": [{"operation": "rescan"}]}',
                               headers={'content-type': 'application/json'})
         self.assertEqual(204, response.code)
         self.client_mock.rescanSystemDirectory.assert_called_once_with()
@@ -30,13 +32,15 @@ class AdminAPITest(TestHandlerBase):
         self.client_mock.rescanSystemDirectory.return_value = self.future_mock
         self.future_mock.set_exception(ValueError())
 
-        response = self.fetch('/api/v1/admin/', method='PATCH', body='{"operations": [{"operation": "rescan"}]}',
+        response = self.fetch('/api/v1/admin/', method='PATCH',
+                              body='{"operations": [{"operation": "rescan"}]}',
                               headers={'content-type': 'application/json'})
         self.assertGreaterEqual(response.code, 500)
         self.client_mock.rescanSystemDirectory.assert_called_once_with()
 
     def test_patch_bad_operation(self):
-        response = self.fetch('/api/v1/admin/', method='PATCH', body='{"operations": [{"operation": "fake"}]}',
+        response = self.fetch('/api/v1/admin/', method='PATCH',
+                              body='{"operations": [{"operation": "fake"}]}',
                               headers={'content-type': 'application/json'})
         self.assertGreaterEqual(response.code, 400)
         self.assertLess(response.code, 500)

--- a/test/unit/controllers/command_list_api_test.py
+++ b/test/unit/controllers/command_list_api_test.py
@@ -3,7 +3,8 @@ import mongoengine.errors
 from . import TestHandlerBase
 
 
-@patch('brew_view.controllers.command_list_api.Command.objects', Mock(all=Mock(return_value=['cmd1', 'cmd2'])))
+@patch('brew_view.controllers.command_list_api.Command.objects',
+       Mock(all=Mock(return_value=['cmd1', 'cmd2'])))
 class CommandListAPITest(TestHandlerBase):
 
     @patch('brew_view.controllers.command_list_api.CommandListAPI.parser')
@@ -11,7 +12,8 @@ class CommandListAPITest(TestHandlerBase):
         parser_mock.serialize_command = Mock(return_value='serialized_commands')
         response = self.fetch('/api/v1/commands')
         self.assertEqual('serialized_commands', response.body.decode("utf-8"))
-        parser_mock.serialize_command.assert_called_once_with(['cmd1', 'cmd2'], many=True, to_string=True)
+        parser_mock.serialize_command.assert_called_once_with(['cmd1', 'cmd2'],
+                                                              many=True, to_string=True)
 
     @patch('brew_view.controllers.command_list_api.CommandListAPI.parser')
     def test_get_throw_does_not_exist_return_500(self, parser_mock):

--- a/test/unit/controllers/instance_api_test.py
+++ b/test/unit/controllers/instance_api_test.py
@@ -13,13 +13,16 @@ class InstanceAPITest(TestHandlerBase):
         get_mock = mongo_patcher.start()
         get_mock.return_value.get.return_value = self.instance_mock
 
-        serialize_patcher = patch('brew_view.controllers.instance_api.BeerGardenSchemaParser.serialize_instance')
+        serialize_patcher = patch(
+            'brew_view.controllers.instance_api.BeerGardenSchemaParser.serialize_instance'
+        )
         self.addCleanup(serialize_patcher.stop)
         self.serialize_mock = serialize_patcher.start()
         self.serialize_mock.return_value = 'serialized_instance'
 
         self.client_mock = Mock(name='client_mock')
-        self.fake_context = MagicMock(__enter__=Mock(return_value=self.client_mock), __exit__=Mock(return_value=False))
+        self.fake_context = MagicMock(__enter__=Mock(return_value=self.client_mock),
+                                      __exit__=Mock(return_value=False))
 
         super(InstanceAPITest, self).setUp()
 
@@ -33,7 +36,8 @@ class InstanceAPITest(TestHandlerBase):
     def test_patch_initialize(self, context_mock):
         context_mock.return_value = self.fake_context
 
-        self.fetch('/api/v1/instances/id', method='PATCH', body='{"operations": [{"operation": "initialize"}]}',
+        self.fetch('/api/v1/instances/id', method='PATCH',
+                   body='{"operations": [{"operation": "initialize"}]}',
                    headers={'content-type': 'application/json'})
         self.client_mock.initializeInstance.assert_called_once_with('id')
 
@@ -41,7 +45,8 @@ class InstanceAPITest(TestHandlerBase):
     def test_patch_start(self, context_mock):
         context_mock.return_value = self.fake_context
 
-        self.fetch('/api/v1/instances/id', method='PATCH', body='{"operations": [{"operation": "start"}]}',
+        self.fetch('/api/v1/instances/id', method='PATCH',
+                   body='{"operations": [{"operation": "start"}]}',
                    headers={'content-type': 'application/json'})
         self.client_mock.startInstance.assert_called_once_with('id')
 
@@ -49,7 +54,8 @@ class InstanceAPITest(TestHandlerBase):
     def test_patch_stop(self, context_mock):
         context_mock.return_value = self.fake_context
 
-        self.fetch('/api/v1/instances/id', method='PATCH', body='{"operations": [{"operation": "stop"}]}',
+        self.fetch('/api/v1/instances/id', method='PATCH',
+                   body='{"operations": [{"operation": "stop"}]}',
                    headers={'content-type': 'application/json'})
         self.client_mock.stopInstance.assert_called_once_with('id')
 
@@ -58,7 +64,8 @@ class InstanceAPITest(TestHandlerBase):
     def test_patch_heartbeat(self, context_mock):
         context_mock.return_value = self.fake_context
 
-        self.fetch('/api/v1/instances/id', method='PATCH', body='{"operations": [{"operation": "heartbeat"}]}',
+        self.fetch('/api/v1/instances/id', method='PATCH',
+                   body='{"operations": [{"operation": "heartbeat"}]}',
                    headers={'content-type': 'application/json'})
         self.assertEqual('now', self.instance_mock.status_info.heartbeat)
 
@@ -66,6 +73,7 @@ class InstanceAPITest(TestHandlerBase):
     def test_patch_bad_operation(self, context_mock):
         context_mock.return_value = self.fake_context
 
-        response = self.fetch('/api/v1/instances/id', method='PATCH', body='{"operations": [{"operation": "fake"}]}',
+        response = self.fetch('/api/v1/instances/id', method='PATCH',
+                              body='{"operations": [{"operation": "fake"}]}',
                               headers={'content-type': 'application/json'})
         self.assertGreaterEqual(response.code, 400)

--- a/test/unit/controllers/logging_api_test.py
+++ b/test/unit/controllers/logging_api_test.py
@@ -2,7 +2,7 @@ import unittest
 import json
 
 from . import TestHandlerBase
-from mock import Mock, patch
+from mock import patch
 from test.unit.utils import TestUtils
 
 

--- a/test/unit/controllers/misc_controller_test.py
+++ b/test/unit/controllers/misc_controller_test.py
@@ -14,14 +14,16 @@ class ConfigHandlerTest(TestHandlerBase):
         brew_view.config['application_name'] = 'Rock Garden'
 
         response = self.fetch('/config')
-        self.assertEqual('Rock Garden', json.loads(response.body.decode('utf-8'))['application_name'])
+        self.assertEqual('Rock Garden',
+                         json.loads(response.body.decode('utf-8'))['application_name'])
 
 
 class VersionHandlerTest(TestHandlerBase):
 
     def setUp(self):
         self.client_mock = Mock(name='client_mock')
-        self.fake_context = MagicMock(__enter__=Mock(return_value=self.client_mock), __exit__=Mock(return_value=False))
+        self.fake_context = MagicMock(__enter__=Mock(return_value=self.client_mock),
+                                      __exit__=Mock(return_value=False))
         self.future_mock = Future()
 
         super(VersionHandlerTest, self).setUp()

--- a/test/unit/controllers/queue_api_test.py
+++ b/test/unit/controllers/queue_api_test.py
@@ -7,7 +7,8 @@ class QueueAPITest(TestHandlerBase):
 
     def setUp(self):
         self.client_mock = Mock(name='client_mock')
-        self.fake_context = MagicMock(__enter__=Mock(return_value=self.client_mock), __exit__=Mock(return_value=False))
+        self.fake_context = MagicMock(__enter__=Mock(return_value=self.client_mock),
+                                      __exit__=Mock(return_value=False))
 
         super(QueueAPITest, self).setUp()
 

--- a/test/unit/controllers/queue_list_api_test.py
+++ b/test/unit/controllers/queue_list_api_test.py
@@ -11,12 +11,15 @@ class QueueListAPITest(TestHandlerBase):
     def setUp(self):
         self.instance_mock = Mock(status='RUNNING')
         type(self.instance_mock).name = PropertyMock(return_value='default')
-        self.system_mock = Mock(id='1234', display_name='display', version='1.0.0', instances=[self.instance_mock])
+        self.system_mock = Mock(id='1234', display_name='display', version='1.0.0',
+                                instances=[self.instance_mock])
         type(self.system_mock).name = PropertyMock(return_value='system_name')
-        self.queue_name = "%s[%s]-%s" % (self.system_mock.name, self.instance_mock.name, self.system_mock.version)
+        self.queue_name = "%s[%s]-%s" % (self.system_mock.name, self.instance_mock.name,
+                                         self.system_mock.version)
 
         self.client_mock = Mock(name='client_mock')
-        self.fake_context = MagicMock(__enter__=Mock(return_value=self.client_mock), __exit__=Mock(return_value=False))
+        self.fake_context = MagicMock(__enter__=Mock(return_value=self.client_mock),
+                                      __exit__=Mock(return_value=False))
         self.future_mock = Future()
 
         super(QueueListAPITest, self).setUp()
@@ -41,7 +44,8 @@ class QueueListAPITest(TestHandlerBase):
 
         response = self.fetch('/api/v1/queues')
         output = json.loads(response.body.decode('utf-8'))
-        self.client_mock.getQueueInfo.assert_called_once_with(self.system_mock.name, self.system_mock.version,
+        self.client_mock.getQueueInfo.assert_called_once_with(self.system_mock.name,
+                                                              self.system_mock.version,
                                                               self.instance_mock.name)
         self.assertEqual(1, len(output))
         self.assertDictEqual({

--- a/test/unit/controllers/request_api_test.py
+++ b/test/unit/controllers/request_api_test.py
@@ -16,7 +16,9 @@ class RequestAPITest(TestHandlerBase):
         self.get_mock = mongo_patcher.start()
         self.get_mock.return_value.get.return_value = self.request_mock
 
-        serialize_patcher = patch('brew_view.controllers.request_api.BeerGardenSchemaParser.serialize_request')
+        serialize_patcher = patch(
+            'brew_view.controllers.request_api.BeerGardenSchemaParser.serialize_request'
+        )
         self.addCleanup(serialize_patcher.stop)
         self.serialize_mock = serialize_patcher.start()
         self.serialize_mock.return_value = 'serialized_request'
@@ -29,7 +31,8 @@ class RequestAPITest(TestHandlerBase):
         self.assertEqual(self.serialize_mock.return_value, response.body.decode('utf-8'))
 
     def test_patch_replace_status(self):
-        body = json.dumps({"operations": [{"operation": "replace", "path": "/status", "value": "SUCCESS"}]})
+        body = json.dumps({"operations": [{"operation": "replace", "path": "/status",
+                                           "value": "SUCCESS"}]})
 
         response = self.fetch('/api/v1/requests/id', method='PATCH', body=body,
                               headers={'content-type': 'application/json'})
@@ -39,7 +42,8 @@ class RequestAPITest(TestHandlerBase):
         self.assertTrue(self.request_mock.save.called)
 
     def test_patch_replace_output(self):
-        body = json.dumps({"operations": [{"operation": "replace", "path": "/output", "value": "output"}]})
+        body = json.dumps({"operations": [{"operation": "replace", "path": "/output",
+                                           "value": "output"}]})
 
         response = self.fetch('/api/v1/requests/id', method='PATCH', body=body,
                               headers={'content-type': 'application/json'})
@@ -49,7 +53,8 @@ class RequestAPITest(TestHandlerBase):
         self.assertTrue(self.request_mock.save.called)
 
     def test_patch_replace_error_class(self):
-        body = json.dumps({"operations": [{"operation": "replace", "path": "/error_class", "value": "error"}]})
+        body = json.dumps({"operations": [{"operation": "replace", "path": "/error_class",
+                                           "value": "error"}]})
 
         response = self.fetch('/api/v1/requests/id', method='PATCH', body=body,
                               headers={'content-type': 'application/json'})
@@ -59,14 +64,16 @@ class RequestAPITest(TestHandlerBase):
         self.assertTrue(self.request_mock.save.called)
 
     def test_patch_replace_bad_status(self):
-        body = json.dumps({"operations": [{"operation": "replace", "path": "/status", "value": "bad"}]})
+        body = json.dumps({"operations": [{"operation": "replace", "path": "/status",
+                                           "value": "bad"}]})
         response = self.fetch('/api/v1/requests/id', method='PATCH', body=body,
                               headers={'content-type': 'application/json'})
         self.assertGreaterEqual(response.code, 400)
 
     def test_patch_update_output_for_complete_request(self):
         self.request_mock.status = "SUCCESS"
-        body = json.dumps({"operations": [{"operation": "replace", "path": "/output", "value": "shouldnt work"}]})
+        body = json.dumps({"operations": [{"operation": "replace", "path": "/output",
+                                           "value": "shouldnt work"}]})
         response = self.fetch("/api/v1/requests/id", method='PATCH', body=body,
                               headers={'content-type': 'application/json'})
         self.assertGreaterEqual(response.code, 400)
@@ -74,18 +81,20 @@ class RequestAPITest(TestHandlerBase):
     def test_patch_no_system(self):
         self.get_mock.return_value.get.side_effect = DoesNotExist
 
-        response = self.fetch('/api/v1/requests/id', method='PATCH', body='{"operations": [{"operation": "fake"}]}',
+        response = self.fetch('/api/v1/requests/id', method='PATCH',
+                              body='{"operations": [{"operation": "fake"}]}',
                               headers={'content-type': 'application/json'})
         self.assertGreaterEqual(response.code, 400)
 
     def test_patch_replace_bad_path(self):
-        body = json.dumps({"operations": [{"operation": "replace", "path": "/bad", "value": "error"}]})
+        body = json.dumps({"operations": [{"operation": "replace", "path": "/bad",
+                                           "value": "error"}]})
         response = self.fetch('/api/v1/requests/id', method='PATCH', body=body,
                               headers={'content-type': 'application/json'})
         self.assertGreaterEqual(response.code, 400)
 
     def test_patch_bad_operation(self):
-        response = self.fetch('/api/v1/requests/id', method='PATCH', body='{"operations": [{"operation": "fake"}]}',
+        response = self.fetch('/api/v1/requests/id', method='PATCH',
+                              body='{"operations": [{"operation": "fake"}]}',
                               headers={'content-type': 'application/json'})
         self.assertGreaterEqual(response.code, 400)
-

--- a/test/unit/controllers/request_list_api_test.py
+++ b/test/unit/controllers/request_list_api_test.py
@@ -22,13 +22,16 @@ class RequestListAPITest(TestHandlerBase):
         self.mongo_mock = mongo_patcher.start()
         self.mongo_mock.count.return_value = 1
 
-        serialize_patcher = patch('brew_view.controllers.request_list_api.BeerGardenSchemaParser.serialize_request')
+        serialize_patcher = patch(
+            'brew_view.controllers.request_list_api.BeerGardenSchemaParser.serialize_request'
+        )
         self.addCleanup(serialize_patcher.stop)
         self.serialize_mock = serialize_patcher.start()
         self.serialize_mock.return_value = 'serialized_request'
 
         self.client_mock = Mock(name='client_mock')
-        self.fake_context = MagicMock(__enter__=Mock(return_value=self.client_mock), __exit__=Mock(return_value=False))
+        self.fake_context = MagicMock(__enter__=Mock(return_value=self.client_mock),
+                                      __exit__=Mock(return_value=False))
         self.future_mock = Future()
 
         super(RequestListAPITest, self).setUp()
@@ -39,7 +42,8 @@ class RequestListAPITest(TestHandlerBase):
 
         response = self.fetch('/api/v1/requests?draw=1')
         self.assertEqual(200, response.code)
-        self.serialize_mock.assert_called_once_with(['request'], many=True, only=None, to_string=True)
+        self.serialize_mock.assert_called_once_with(['request'], many=True, only=None,
+                                                    to_string=True)
         self.assertEqual('0', response.headers['start'])
         self.assertEqual('1', response.headers['length'])
         self.assertEqual('1', response.headers['recordsFiltered'])
@@ -60,7 +64,8 @@ class RequestListAPITest(TestHandlerBase):
         type(instance_mock).name = PropertyMock(return_value='default')
         system_mock.get.return_value = Mock(instances=[instance_mock])
 
-        response = self.fetch('/api/v1/requests', method='POST', body='', headers={'content-type': 'application/json'})
+        response = self.fetch('/api/v1/requests', method='POST', body='',
+                              headers={'content-type': 'application/json'})
         self.assertEqual(201, response.code)
         self.assertEqual('RUNNING', response.headers['Instance-Status'])
         self.assertTrue(self.request_mock.save.called)
@@ -74,7 +79,8 @@ class RequestListAPITest(TestHandlerBase):
         self.future_mock.set_exception(bg_utils.bg_thrift.InvalidRequest())
         parse_mock.return_value = self.request_mock
 
-        response = self.fetch('/api/v1/requests', method='POST', body='', headers={'content-type': 'application/json'})
+        response = self.fetch('/api/v1/requests', method='POST', body='',
+                              headers={'content-type': 'application/json'})
         self.assertGreaterEqual(response.code, 400)
         self.assertTrue(self.request_mock.delete.called)
         self.assertTrue(self.client_mock.processRequest.called)
@@ -86,12 +92,14 @@ class RequestListAPITest(TestHandlerBase):
         self.future_mock.set_exception(Exception())
         parse_mock.return_value = self.request_mock
 
-        response = self.fetch('/api/v1/requests', method='POST', body='', headers={'content-type': 'application/json'})
+        response = self.fetch('/api/v1/requests', method='POST', body='',
+                              headers={'content-type': 'application/json'})
         self.assertGreaterEqual(response.code, 400)
         self.assertTrue(self.request_mock.delete.called)
 
     def test_post_no_content_type(self):
-        response = self.fetch('/api/v1/requests', method='POST', body='', headers={'content-type': 'text/plain'})
+        response = self.fetch('/api/v1/requests', method='POST', body='',
+                              headers={'content-type': 'text/plain'})
         self.assertEqual(response.code, 400)
 
     @patch('brew_view.controllers.request_list_api.BeerGardenSchemaParser.parse_request')
@@ -103,7 +111,8 @@ class RequestListAPITest(TestHandlerBase):
         parse_mock.return_value = self.request_mock
         self.mongo_mock.get.return_value = self.request_mock
 
-        response = self.fetch('/api/v1/requests', method='POST', body='', headers={'content-type': 'application/json'})
+        response = self.fetch('/api/v1/requests', method='POST', body='',
+                              headers={'content-type': 'application/json'})
         self.assertEqual(201, response.code)
         self.assertIn('Instance-Status', response.headers)
         self.assertEqual('UNKNOWN', response.headers['Instance-Status'])

--- a/test/unit/controllers/system_api_test.py
+++ b/test/unit/controllers/system_api_test.py
@@ -19,7 +19,8 @@ class SystemAPITest(TestHandlerBase, TestUtils):
         self.get_mock.return_value.get.return_value = self.system_mock
 
         self.client_mock = Mock(name='client_mock')
-        self.fake_context = MagicMock(__enter__=Mock(return_value=self.client_mock), __exit__=Mock(return_value=False))
+        self.fake_context = MagicMock(__enter__=Mock(return_value=self.client_mock),
+                                      __exit__=Mock(return_value=False))
         self.future_mock = Future()
 
         super(SystemAPITest, self).setUp()
@@ -55,7 +56,8 @@ class SystemAPITest(TestHandlerBase, TestUtils):
     @patch('brew_view.controllers.system_api.BeerGardenSchemaParser.parse_command', Mock())
     @patch('brew_view.controllers.system_api.BeerGardenSchemaParser.serialize_system')
     def test_patch_replace_commands_ok(self, serialize_mock):
-        body = json.dumps({"operations": [{"operation": "replace", "path": "/commands", "value": "output"}]})
+        body = json.dumps({"operations": [{"operation": "replace", "path": "/commands",
+                                           "value": "output"}]})
         serialize_mock.return_value = 'serialized_system'
 
         response = self.fetch('/api/v1/systems/id', method='PATCH', body=body,
@@ -68,7 +70,8 @@ class SystemAPITest(TestHandlerBase, TestUtils):
     @patch('brew_view.controllers.system_api.BeerGardenSchemaParser.serialize_system')
     def test_patch_replace_commands_bad(self, serialize_mock):
         self.system_mock.commands = ['a command']
-        body = json.dumps({"operations": [{"operation": "replace", "path": "/commands", "value": "output"}]})
+        body = json.dumps({"operations": [{"operation": "replace", "path": "/commands",
+                                           "value": "output"}]})
         serialize_mock.return_value = 'serialized_system'
 
         response = self.fetch('/api/v1/systems/id', method='PATCH', body=body,
@@ -84,7 +87,8 @@ class SystemAPITest(TestHandlerBase, TestUtils):
         self.future_mock.set_result(None)
         serialize_mock.return_value = 'serialized_system'
 
-        response = self.fetch('/api/v1/systems/id', method='PATCH', body='{"operations": [{"operation": "reload"}]}',
+        response = self.fetch('/api/v1/systems/id', method='PATCH',
+                              body='{"operations": [{"operation": "reload"}]}',
                               headers={'content-type': 'application/json'})
         self.assertEqual(200, response.code)
         self.assertEqual('serialized_system', response.body.decode('utf-8'))
@@ -94,7 +98,8 @@ class SystemAPITest(TestHandlerBase, TestUtils):
     @patch('brew_view.controllers.system_api.BeerGardenSchemaParser.serialize_system')
     def test_patch_update_metadata(self, serialize_mock):
         self.system_mock.metadata = {"foo": "baz"}
-        body = json.dumps({"operations": [{"operation": "update", "path": "/metadata", "value": {"foo": "bar"}}]})
+        body = json.dumps({"operations": [{"operation": "update", "path": "/metadata",
+                                           "value": {"foo": "bar"}}]})
         serialize_mock.return_value = 'serialized_system'
 
         response = self.fetch('/api/v1/systems/id', method='PATCH', body=body,
@@ -107,7 +112,8 @@ class SystemAPITest(TestHandlerBase, TestUtils):
     @patch('brew_view.controllers.system_api.BeerGardenSchemaParser.serialize_system')
     def test_patch_replace_description(self, serialize_mock):
         self.system_mock.description = "old_description"
-        body = json.dumps({"operations": [{"operation": "replace", "path": "/description", "value": "new_description"}]})
+        body = json.dumps({"operations": [{"operation": "replace", "path": "/description",
+                                           "value": "new_description"}]})
         serialize_mock.return_value = 'serialized_system'
 
         response = self.fetch('/api/v1/systems/id', method='PATCH', body=body,
@@ -120,7 +126,8 @@ class SystemAPITest(TestHandlerBase, TestUtils):
     @patch('brew_view.controllers.system_api.BeerGardenSchemaParser.serialize_system')
     def test_patch_replace_null_empty_string(self, serialize_mock):
         self.system_mock.description = "old_description"
-        body = json.dumps({"operations": [{"operation": "replace", "path": "/description", "value": None}]})
+        body = json.dumps({"operations": [{"operation": "replace", "path": "/description",
+                                           "value": None}]})
         serialize_mock.return_value = 'serialized_system'
 
         response = self.fetch('/api/v1/systems/id', method='PATCH', body=body,
@@ -132,7 +139,8 @@ class SystemAPITest(TestHandlerBase, TestUtils):
     @patch('brew_view.controllers.system_api.BeerGardenSchemaParser.parse_command', Mock())
     @patch('brew_view.controllers.system_api.BeerGardenSchemaParser.serialize_system')
     def test_patch_invalid_path_for_update(self, serialize_mock):
-        body = json.dumps({"operations": [{"operation": "update", "path": "/INVALID", "value": "doesnt_matter"}]})
+        body = json.dumps({"operations": [{"operation": "update", "path": "/INVALID",
+                                           "value": "doesnt_matter"}]})
         serialize_mock.return_value = 'serialized_system'
 
         response = self.fetch('/api/v1/systems/id', method='PATCH', body=body,
@@ -142,17 +150,20 @@ class SystemAPITest(TestHandlerBase, TestUtils):
     def test_patch_no_system(self):
         self.get_mock.return_value.get.side_effect = DoesNotExist
 
-        response = self.fetch('/api/v1/systems/id', method='PATCH', body='{"operations": [{"operation": "fake"}]}',
+        response = self.fetch('/api/v1/systems/id', method='PATCH',
+                              body='{"operations": [{"operation": "fake"}]}',
                               headers={'content-type': 'application/json'})
         self.assertGreaterEqual(response.code, 400)
 
     def test_patch_replace_bad_path(self):
-        body = json.dumps({"operations": [{"operation": "replace", "path": "/bad", "value": "error"}]})
+        body = json.dumps({"operations": [{"operation": "replace",
+                                           "path": "/bad", "value": "error"}]})
         response = self.fetch('/api/v1/systems/id', method='PATCH', body=body,
                               headers={'content-type': 'application/json'})
         self.assertGreaterEqual(response.code, 400)
 
     def test_patch_bad_operation(self):
-        response = self.fetch('/api/v1/systems/id', method='PATCH', body='{"operations": [{"operation": "fake"}]}',
+        response = self.fetch('/api/v1/systems/id', method='PATCH',
+                              body='{"operations": [{"operation": "fake"}]}',
                               headers={'content-type': 'application/json'})
         self.assertGreaterEqual(response.code, 400)

--- a/test/unit/controllers/system_list_api_test.py
+++ b/test/unit/controllers/system_list_api_test.py
@@ -16,7 +16,9 @@ class SystemListAPITest(TestHandlerBase, TestUtils):
         self.get_mock = mongo_patcher.start()
         self.get_mock.return_value = self.system_mock
 
-        serialize_patcher = patch('brew_view.controllers.system_list_api.BeerGardenSchemaParser.serialize_system')
+        serialize_patcher = patch(
+            'brew_view.controllers.system_list_api.BeerGardenSchemaParser.serialize_system'
+        )
         self.addCleanup(serialize_patcher.stop)
         self.serialize_mock = serialize_patcher.start()
         self.serialize_mock.return_value = 'serialized_system'

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [flake8]
 max-line-length = 100
+exclude = brew_view/static
 
 [tox]
 envlist = py27, py35, py36, flake8


### PR DESCRIPTION
This PR is for linting. Both flake8 and ESLint. ESLint is by far the bigger of the two changes.

We are now running ESLint for all our JavaScript code. We followed the Google style guide with one modification, we allow 100 characters on a line. 

This change also included us moving over to ES6 in our JavaScript. This came with it's own headache as the production build stopped working because the Uglify plugin only allows ES5. So, I had to add a transpiling step during the webpack build. I have tested this both locally and by building the production image and both of them work as expected. 

I also updated the `.travis.yml` to include running ESLint during each new contribution. So we will at least have a standard now.

Flake8 support was mostly minor. Just fixed a few spacing issues and line-length, that was about it.