### PR TITLE
Issue/47

### DIFF
--- a/brew_view/static/src/js/controllers/command_view.js
+++ b/brew_view/static/src/js/controllers/command_view.js
@@ -89,7 +89,8 @@ export default function commandViewController(
       command: requestPrototype['command'],
       system: requestPrototype['system'] || $scope.system.name,
       system_version: requestPrototype['system_version'] || $scope.system.version,
-      instance_name: requestPrototype['instance_name'] || 'default',
+      instance_name: requestPrototype['instance_name'] || $scope.model['instance_name'] ||
+          'default',
     };
 
     // If parameters are specified we need to use the model value

--- a/brew_view/static/src/js/services/sf_builder_service.js
+++ b/brew_view/static/src/js/services/sf_builder_service.js
@@ -414,7 +414,10 @@ export function sfBuilderService($rootScope, sfPath, UtilityService) {
       // Then populate the choices
       // Simple case - static list of choices
       if (parameter.choices.type === 'static') {
-        form['choices'] = {titleMap: parameter.choices.value};
+        form['choices'] = {
+          updateOn: [],
+          titleMap: parameter.choices.value,
+        };
 
         if (parameter.choices.details && parameter.choices.details.key_reference) {
           let field = parentKey + '.' + parameter.choices.details.key_reference;
@@ -440,7 +443,7 @@ export function sfBuilderService($rootScope, sfPath, UtilityService) {
         }
       } else if (parameter.choices.type === 'command') {
         form['choices'] = {
-          updateOn: [],
+          updateOn: ['instance_name'],
           callback: {
             function: 'createRequestWrapper',
             arguments: [{


### PR DESCRIPTION
This fixes the issue with the frontend where a plugin that uses a command as a choice source will always address the request to the `default` instance. That's a problem if the plugin doesn't have an instance named `default`.

This PR keeps the current behavior as the default. However, now when the user selects an alternate instance name all command-based choices will be re-executed and the choice lists will be updated.

This means that we still can't populate command-based choices until the user selects an instance. So until they do the choices will be empty. I don't see any way around that.

I think the correct thing to do is to add some sort of visual linkage for choices. Right now I've been putting things like that in the description ('this parameter depends on parameter foo'), but it would be nice to have better support for that. Then we could have some small indicator that would let the user know that the *reason* the choices are empty is because they haven't selected an instance name yet.