### PR TITLE
Updating Prometheus Metrics for Grafana Dashboards

### DIFF
--- a/brew_view/base_handler.py
+++ b/brew_view/base_handler.py
@@ -3,7 +3,7 @@ import socket
 
 import time
 from mongoengine.errors import DoesNotExist, NotUniqueError, ValidationError as MongoValidationError
-from prometheus_client import Histogram, Gauge
+from prometheus_client import Gauge, Counter, Summary
 from thriftpy.thrift import TException
 from tornado.web import HTTPError, RequestHandler
 
@@ -17,15 +17,42 @@ class BaseHandler(RequestHandler):
     """Base handler from which all handlers inherit. Enables CORS and error handling."""
 
     MONGO_ID_PATTERN = r'.*/([0-9a-f]{24}).*'
-    queued_request_gauge = Gauge(
-        'bg_waiting_requests',
-        'Number of requests that have not been completed',
-        ['system', 'instance']
+
+    # Prometheus metrics.
+    # Summaries:
+    http_api_latency_total = Summary(
+        'bg_http_api_latency_seconds',
+        'Total number of seconds each API endpoint is taking to respond.',
+        ['method', 'route', 'status']
     )
-    http_api_latency = Histogram(
-        'bg_http_api_latency_millis',
-        'Testing out http totals.',
-        ['method', 'endpoint']
+    plugin_command_latency = Summary(
+        'bg_plugin_command_latency_seconds',
+        'Total time taken for a command to complete in seconds.',
+        ['system', 'instance_name', 'system_version', 'command', 'status'],
+    )
+
+    # Counters:
+    completed_request_counter = Counter(
+        'bg_completed_requests_total',
+        'Number of completed requests.',
+        ['system', 'instance_name', 'system_version', 'command', 'status'],
+    )
+    request_counter_total = Counter(
+        'bg_requests_total',
+        'Number of requests.',
+        ['system', 'instance_name', 'system_version', 'command'],
+    )
+
+    # Gauges:
+    queued_request_gauge = Gauge(
+        'bg_queued_requests',
+        'Number of requests waiting to be processed.',
+        ['system', 'instance_name', 'system_version'],
+    )
+    in_progress_request_gauge = Gauge(
+        'bg_in_progress_requests',
+        'Number of requests IN_PROGRESS',
+        ['system', 'instance_name', 'system_version'],
     )
 
     def __init__(self, *args, **kwargs):
@@ -56,21 +83,20 @@ class BaseHandler(RequestHandler):
             self.set_header("Access-Control-Allow-Methods", "GET, POST, PATCH, DELETE, OPTIONS")
 
     @property
-    def current_time_millis(self):
-        """Current time in Milliseconds."""
-        return int(round(time.time() * 1000))
-
-    @property
     def prometheus_endpoint(self):
         """Removes Mongo ID from endpoint."""
-        to_return = self.request.path
+        to_return = self.request.path.rstrip('/')
         for mongo_id in re.findall(self.MONGO_ID_PATTERN, self.request.path):
             to_return = to_return.replace(mongo_id, '<ID>')
         return to_return
 
     def prepare(self):
         """Called before each verb handler"""
-        self.request.created_time_ms = self.current_time_millis
+
+        # Used for recording prometheus metrics.
+        # We keep this time in seconds, also time-zone does not matter
+        # because we are just calculating a duration.
+        self.request.created_time = time.time()
 
         # This is used for sending event notifications
         self.request.event = Event()
@@ -96,9 +122,10 @@ class BaseHandler(RequestHandler):
 
     def on_finish(self):
         """Called after a handler completes processing"""
-        self.http_api_latency.labels(
+        self.http_api_latency_total.labels(
             method=self.request.method.upper(),
-            endpoint=self.prometheus_endpoint,
+            route=self.prometheus_endpoint,
+            status=self.get_status(),
         ).observe(self._measure_latency())
 
         if self.request.event.name:
@@ -106,7 +133,8 @@ class BaseHandler(RequestHandler):
                                                      **self.request.event_extras)
 
     def _measure_latency(self):
-        return self.current_time_millis - self.request.created_time_ms
+        """We measure the latency in seconds as a float."""
+        return time.time() - self.request.created_time
 
     def options(self, *args, **kwargs):
 

--- a/brew_view/controllers/misc_controllers.py
+++ b/brew_view/controllers/misc_controllers.py
@@ -23,6 +23,7 @@ class ConfigHandler(BaseHandler):
             'icon_default': brew_view.config.application.icon_default,
             'debug_mode': brew_view.config.debug_mode,
             'url_prefix': brew_view.config.web.url_prefix,
+            'metrics_url': brew_view.config.metrics.url,
         }
         self.write(configs)
 

--- a/brew_view/controllers/request_list_api.py
+++ b/brew_view/controllers/request_list_api.py
@@ -289,7 +289,14 @@ class RequestListAPI(BaseHandler):
         self.set_status(201)
         self.queued_request_gauge.labels(
             system=request_model.system,
-            instance=request_model.instance_name
+            system_version=request_model.system_version,
+            instance_name=request_model.instance_name,
+        ).inc()
+        self.request_counter_total.labels(
+            system=request_model.system,
+            system_version=request_model.system_version,
+            instance_name=request_model.instance_name,
+            command=request_model.command,
         ).inc()
         self.write(self.parser.serialize_request(request_model, to_string=False))
 

--- a/brew_view/specification.py
+++ b/brew_view/specification.py
@@ -289,6 +289,11 @@ SPECIFICATION = {
                 'type': 'int',
                 'description': 'Port for prometheus server to listen on.',
                 'default': 2338
+            },
+            'url': {
+                'type': 'str',
+                'description': 'URL to prometheus/grafana server.',
+                'required': False,
             }
         }
     },

--- a/brew_view/static/src/partials/about.html
+++ b/brew_view/static/src/partials/about.html
@@ -4,11 +4,22 @@
   <div class="row">
     <div class="col-md-4">
       <div class="panel panel-default">
-        <div class="panel-heading">Rest API Documentation</div>
+        <div class="panel-heading">Heplful Links</div>
         <div class="panel-body">
-          <p>{{config.applicationName}} uses Swagger to provide API documentation. The Swagger UI is actually pretty
-            nice. The Swagger UI will help you explore the commands available to you in the REST Interface.</p>
-          <a class="btn btn-default center-block" href="{{config.urlPrefix}}swagger/index.html?config={{config.urlPrefix}}config/swagger">Check it out!</a>
+          <ul>
+            <li>
+              <a href="{{config.urlPrefix}}swagger/index.html?config={{config.urlPrefix}}config/swagger">Open API documentation</a> - {{config.applicationName}} uses OpenAPI Documentation for our ReST Interface.
+            </li>
+            <li ng-if="config.metricsUrl">
+              <a href="{{config.metricsUrl}}">Metrics</a> - Link to the configured metrics backend.
+            </li>
+            <li>
+              <a href="https://grafana.com/dashboards/6621">Grafana Dashboard (Beer Garden)</a> - A grafana dashboard for monitoring Beer Garden Performance.
+            </li>
+            <li>
+              <a href="https://grafana.com/dashboards/6624">Grafana Dashboard (Plugins)</a> - A grafana dashboard for monitoring Beer Garden plugin performance.
+            </li>
+          </ul>
         </div>
       </div>
     </div>

--- a/dev_conf/config.yml
+++ b/dev_conf/config.yml
@@ -45,6 +45,9 @@ log:
   config_file: dev_conf/logging-config.json
   file: null
   level: INFO
+metrics:
+  port: 2338
+  url: http://localhost:3000
 plugin_logging:
   config_file: null
   level: INFO


### PR DESCRIPTION
# Note

I did not realize we had already moved to develop. So this is branched from master.

## Updated Prometheus metrics.
Moved away from histograms, since I don't really know the
quantiles we support yet. It is probably likely that we
will eventually want to use histograms, until that time
we are going to be using summaries because they are less
overhead.

Moved from milliseconds to seconds, as that is the standard
practice that prometheus recommends. See more information
here: https://prometheus.io/docs/practices/naming/#base-units


## Added metrics links to GUI.
Needed to expose a possible metrics URL. This does not need
to be set if no metrics are being monitored, but if it is set
it will show up in the about page.

I added the new defaults to the `dev_conf/config.yml`.


## Fixed bug when cancelling requests. 
It is possible for requests to be canceled directly from
being CREATED. If so, we do not want to decrement the
in progress gauge as it leads to negative numbers, which
we never need.