### PR TITLE
UI Routing

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,7 +75,7 @@ Now start up the Python API:
 .. code-block:: console
 
     $ cd /path/to/brew-view
-    $ python -m brew_view -c ./dev_conf/config.json
+    $ python -m brew_view -c ./dev_conf/config.yml
 
 Sweet! Everything should now be up and running. Visit http://localhost:8080/ in a browser to check it out. Hit Ctrl-c to stop the web server.
 
@@ -85,7 +85,7 @@ NOTE: It's worth noting that the JavaScript App is served on 8080 but the python
 Configuration
 =============
 
-There's a conf/config.json file that comes with the installation. It comes with sensible default values but feel free to change them if you'd like. You'll need to restart the web server after making any changes.
+There's a conf/config.yml file that comes with the installation. It comes with sensible default values but feel free to change them if you'd like. You'll need to restart the web server after making any changes.
 
 
 REST Services

--- a/brew_view/controllers/request_api.py
+++ b/brew_view/controllers/request_api.py
@@ -173,7 +173,7 @@ class RequestAPI(BaseHandler):
         if status_before == 'CREATED':
             self.queued_request_gauge.labels(**labels).dec()
         elif status_before == 'IN_PROGRESS':
-            self.in_progress_request_gauge(**labels).dec()
+            self.in_progress_request_gauge.labels(**labels).dec()
 
         if request.status == 'IN_PROGRESS':
             self.in_progress_request_gauge.labels(**labels).inc()

--- a/brew_view/static/src/index.html
+++ b/brew_view/static/src/index.html
@@ -60,7 +60,7 @@
 
               <ul class="nav nav-second-level">
                 <li ng-repeat="(name, arr) in systems | groupBy:'name'" ng-init="collapsed=false">
-                  <a ng-if="arr.length == 1" ui-sref="system({id: arr[0].id})" ui-sref-active="active">
+                  <a ng-if="arr.length == 1" ui-sref="system({name: arr[0].name, version: getVersionForUrl(arr[0])})" ui-sref-active="active">
                     <i class="fa fa-cog"></i>
                     <span>{{arr[0].display_name || arr[0].name}}</span>
                   </a>
@@ -71,7 +71,7 @@
                   </a>
                   <ul ng-if="arr.length > 1" ng-style="{'max-height': (!collapsed) ? (arr.length*40 + 'px') : '0px'}" class="nav nav-third-level show-more">
                     <li ng-repeat="system in arr">
-                      <a ui-sref="system({id: system.id})" ui-sref-active="active">
+                      <a ui-sref="system({name: system.name, version: getVersionForUrl(system)})" ui-sref-active="active">
                         <span>{{system.version}}</span>
                       </a>
                     </li>

--- a/brew_view/static/src/js/configs/routes.js
+++ b/brew_view/static/src/js/configs/routes.js
@@ -44,6 +44,16 @@ export default function routeConfig($stateProvider, $urlRouterProvider) {
       controller: 'CommandIndexController',
     })
     .state('command', {
+      url: '/systems/:systemName/:systemVersion/commands/:name',
+      templateUrl: basePath + 'command_view.html',
+      controller: 'CommandViewController',
+      params: {
+        request: null,
+        id: null,
+      },
+    })
+    // Unused by our UI, but helpful for external links.
+    .state('commandID', {
       url: '/commands/:command_id',
       templateUrl: basePath + 'command_view.html',
       controller: 'CommandViewController',

--- a/brew_view/static/src/js/configs/routes.js
+++ b/brew_view/static/src/js/configs/routes.js
@@ -17,10 +17,16 @@ export default function routeConfig($stateProvider, $urlRouterProvider) {
         templateUrl: basePath + 'landing.html',
         controller: 'LandingController',
     })
-    .state('system', {
+    // Unused by our UI, but helpful for external links.
+    .state('systemID', {
       url: '/systems/:id',
       templateUrl: basePath + 'system_view.html',
       controller: 'SystemViewController',
+    })
+    .state('system', {
+      'url': '/systems/:name/:version',
+      'templateUrl': basePath + 'system_view.html',
+      'controller': 'SystemViewController',
     })
     .state('about', {
       url: '/about',

--- a/brew_view/static/src/js/controllers/admin_queue.js
+++ b/brew_view/static/src/js/controllers/admin_queue.js
@@ -1,6 +1,7 @@
 import angular from 'angular';
 
 queueIndexController.$inject = [
+  '$rootScope',
   '$scope',
   '$compile',
   '$window',
@@ -14,6 +15,7 @@ queueIndexController.$inject = [
 
 /**
  * queueIndexController - Angular controller for queue index page.
+ * @param  {$rootScope} $rootScope   Angular's $rootScope object.
  * @param  {$scope} $scope           Angular's $scope object.
  * @param  {$compile} $compile       Angular's $compile object.
  * @param  {$window} $window         Angular's $window object.
@@ -25,6 +27,7 @@ queueIndexController.$inject = [
  * @param  {Object} QueueService     Beer-Garden's queue service object.
  */
 export default function queueIndexController(
+  $rootScope,
   $scope,
   $compile,
   $window,
@@ -93,8 +96,9 @@ export default function queueIndexController(
       .newColumn('system')
       .withTitle('System')
       .renderWith(function(data, type, full) {
+        let version = $rootScope.getVersionForUrl($rootScope.findSystemByID(full.system_id));
         return '<a ui-sref=' +
-               '"system({id: \'' + full.system_id + '\'})">' +
+               '"system({name: \'' + full.system+ '\', version: \'' + version + '\'})">' +
                (full.display || data) + '</a>';
       }),
     DTColumnBuilder

--- a/brew_view/static/src/js/controllers/landing.js
+++ b/brew_view/static/src/js/controllers/landing.js
@@ -84,8 +84,8 @@ export default function landingController(
     $scope.systems.errorMessage = response.data.message;
   };
 
-  $scope.exploreSystem = function(systemId) {
-    $location.path('/systems/' + systemId);
+  $scope.exploreSystem = function(system) {
+    $location.path($rootScope.getSystemUrl(system.id));
   };
 
   SystemService.getSystems().then($scope.successCallback, $scope.failureCallback);

--- a/brew_view/static/src/js/controllers/request_view.js
+++ b/brew_view/static/src/js/controllers/request_view.js
@@ -178,25 +178,21 @@ export default function requestViewController(
   };
 
   $scope.redoRequest = function(request) {
-    RequestService.getCommandId(request).then(
-      function(id) {
-        if (id !== null) {
-          const newRequest = {
-            system: request.system,
-            system_version: request.system_version,
-            command: request.command,
-            instance_name: request.instance_name,
-            comment: request.comment || '',
-            parameters: request.parameters,
-          };
-
-          $state.go('command', {command_id: id, request: newRequest});
-        } else {
-          alert('We\'re sorry, but this command no longer seems to exist.');
-        }
-      },
-      function(data, status, headers, config) {
-        alert('We\'re sorry, but a server error occurred trying to redirect you.');
+    const newRequest = {
+      system: request.system,
+      system_version: request.system_version,
+      command: request.command,
+      instance_name: request.instance_name,
+      comment: request.comment || '',
+      parameters: request.parameters,
+    };
+    $state.go(
+      'command',
+      {
+        name: request.command,
+        systemName: request.system,
+        systemVersion: request.system_version,
+        request: newRequest,
       }
     );
   };

--- a/brew_view/static/src/js/controllers/system_view.js
+++ b/brew_view/static/src/js/controllers/system_view.js
@@ -98,6 +98,21 @@ export default function systemViewController(
     }
   });
 
+  /**
+   * Get the state params required for the $stateProvider to route this command.
+   *
+   * @param {Object} command - command from server.
+   * @return {Object} params for routing.
+   */
+  $scope.getCommandStateParams = function(command) {
+    return {
+      systemName: $scope.system.data.name,
+      systemVersion: $rootScope.getVersionForUrl($scope.system.data),
+      name: command.name,
+      id: command.id,
+    };
+  };
+
   const loadSystem = function(stateParams) {
     let systemId;
     if (!angular.isDefined(stateParams.id)) {
@@ -122,5 +137,4 @@ export default function systemViewController(
       loadSystem($stateParams);
     });
   }
-
 };

--- a/brew_view/static/src/js/controllers/system_view.js
+++ b/brew_view/static/src/js/controllers/system_view.js
@@ -77,7 +77,7 @@ export default function systemViewController(
     $scope.system.loaded = false;
     $scope.system.error = true;
     $scope.system.status = response.status;
-    $scope.system.errorMessage = data.message;
+    $scope.system.errorMessage = response.data.message;
   };
 
   // Register a function that polls if the system is in a transition status

--- a/brew_view/static/src/js/controllers/system_view.js
+++ b/brew_view/static/src/js/controllers/system_view.js
@@ -6,7 +6,6 @@ systemViewController.$inject = [
   '$stateParams',
   '$interval',
   'SystemService',
-  'CommandService',
   'UtilityService',
   'DTOptionsBuilder',
 ];
@@ -18,7 +17,6 @@ systemViewController.$inject = [
  * @param  {$stateParams} $stateParams Angular's $stateParams object.
  * @param  {$interval} $interval       Angular's $interval object.
  * @param  {Object} SystemService      Beer-Garden System Service.
- * @param  {Object} CommandService     Beer-Garden Command Service.
  * @param  {Object} UtilityService     Beer-Garden Utility Service.
  * @param  {Object} DTOptionsBuilder   Object for building Data-Tables objects.
  */
@@ -28,7 +26,6 @@ export default function systemViewController(
   $stateParams,
   $interval,
   SystemService,
-  CommandService,
   UtilityService,
   DTOptionsBuilder) {
   $scope.util = UtilityService;

--- a/brew_view/static/src/js/run.js
+++ b/brew_view/static/src/js/run.js
@@ -52,6 +52,90 @@ export function appRun($rootScope, $state, $stateParams, $cookies, UtilityServic
 
   // Uses cookies to get the current theme
   $rootScope.changeTheme($cookies.get('currentTheme') || 'default');
+
+  const isLaterVersion = function(system1, system2) {
+    let versionParts1 = system1.version.split('.');
+    let versionParts2 = system2.version.split('.');
+
+    for (let i = 0; i < 3; i++) {
+      if (parseInt(versionParts1[i]) > parseInt(versionParts2[i])) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  /**
+   * Converts a system's version to the 'latest' semantic url scheme.
+   * @param {Object} system  - system for which you want the version URL.
+   * @return {string} - either the systems version or 'latest'.
+   */
+  $rootScope.getVersionForUrl = function(system) {
+    for (let sys of $rootScope.systems) {
+      if (sys.name == system.name) {
+        if (isLaterVersion(sys, system)) {
+          return system.version;
+        }
+      }
+    }
+    return 'latest';
+  };
+
+
+  /**
+   * Convert a system ObjectID to a route to use for the router.
+   * @param {string} systemId  - ObjectID for system.
+   * @return {string} url to use for UI routing.
+   */
+  $rootScope.getSystemUrl = function(systemId) {
+    for (let system of $rootScope.systems) {
+      if (system.id == systemId) {
+        let version = this.getVersionForUrl(system);
+        return '/systems/' + system.name + '/' + version;
+      }
+    }
+    return '/systems';
+  };
+
+  /**
+   * Find the system with the specified name/version (version can just
+   * be the string 'latest')
+   *
+   * @param {string} name - The name of the system you wish to find.
+   * @param {string} version - The version you want to find (or latest)
+   * @return {Object} The latest system or undefined if it is not found.
+   */
+  $rootScope.findSystem = function(name, version) {
+    let latestSystem;
+    for (let system of $rootScope.systems) {
+      if (system.name === name) {
+        if (!angular.isDefined(latestSystem)) {
+          latestSystem = system;
+        }
+
+        if (system.version === version) {
+          return system;
+        } else if (version === 'latest' && isLaterVersion(system, latestSystem)) {
+          latestSystem = system;
+        }
+      }
+    }
+    return latestSystem;
+  };
+
+
+  /**
+   * Find the system with the given ID.
+   * @param {string} systemId - System's ObjectID
+   * @return {Object} the system with this ID.
+   */
+  $rootScope.findSystemByID = function(systemId) {
+    for (let system of $rootScope.systems) {
+      if (system.id === systemId) {
+        return system;
+      }
+    }
+  };
 };
 
 

--- a/brew_view/static/src/js/services/command_service.js
+++ b/brew_view/static/src/js/services/command_service.js
@@ -17,12 +17,17 @@ export default function commandService($http, $rootScope, SystemService) {
   },
 
   CommandService.findSystem = function(command) {
-    const systemId = command.system.id;
-    for ( let index in $rootScope.systems ) {
-      if ( systemId == $rootScope.systems[index].id ) {
-        return $rootScope.systems[index];
-      }
-    }
+    return $rootScope.findSystemByID(command.system.id);
+  },
+
+  CommandService.getStateParams = function(command) {
+    let system = $rootScope.findSystemByID(command.system.id);
+    return {
+      systemName: system.name,
+      systemVersion: $rootScope.getVersionForUrl(command.system),
+      name: command.name,
+      id: command.id,
+    };
   },
 
   CommandService.getCommands = function() {

--- a/brew_view/static/src/partials/admin_queue.html
+++ b/brew_view/static/src/partials/admin_queue.html
@@ -13,34 +13,6 @@
 <div class="container-fluid">
   <div ng-show="queues.loaded && !queues.error && queues.data.length">
     <table datatable="" dt-options="dtOptions" dt-columns="dtColumns" dt-instance="instanceCreated" class="table table-striped table-bordered" style="width: 100%">
-    <thead>
-      <tr>
-        <th width="15px"></th>
-        <th>System</th>
-        <th>Version</th>
-        <th>Instance Name</th>
-        <th>Queue Name</th>
-        <th>Queued Messages</th>
-        <th width="10%">Actions</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr ng-repeat="queue in queues.data">
-        <td width="1%">
-          <a ng-href="http://{{queueHost}}:{{queueAdminPort}}/#/queues/{{queueVirtualHost}}/{{queue.name}}" target="_blank">
-            <i class="fa fa-database fa-fw icon-color"></i>
-          </a>
-        </td>
-        <td><a ui-sref="system({id: queue.system_id})">{{queue.display || queue.system}}</a></td>
-        <td>{{queue.version}}</td>
-        <td>{{queue.instance}}</td>
-        <td>{{queue.name}}</td>
-        <td>{{queue.size}}</td>
-        <td>
-          <button type="button" class="btn btn-danger btn-block word-wrap-button" ng-click="clearQueue(queue.name)">Clear Queue</button>
-        </td>
-      </tr>
-    </tbody>
     </table>
     <div uib-alert ng-repeat="alert in alerts" ng-class="'alert-' + alert.type" close="closeAlert($index)" dismiss-on-timeout=5000>
       {{alert.msg}}

--- a/brew_view/static/src/partials/admin_system.html
+++ b/brew_view/static/src/partials/admin_system.html
@@ -22,7 +22,7 @@
         <div class="list-group">
           <div class="list-group-item clearfix" style="font-size: 18px;">
             <div style="display: inline-block; padding-top: 3px; padding-right: 16px;">
-              <a ui-sref="system({id: system.id})">
+              <a ui-sref="system({name: system.name, version: getVersionForUrl(system)})">
                 <span class="icon-color" ng-class="util.getIcon(system.icon_name)"></span>
                 <span style="font-size: 18px;">{{systemVersion}}</span>
               </a>

--- a/brew_view/static/src/partials/command_index.html
+++ b/brew_view/static/src/partials/command_index.html
@@ -22,7 +22,13 @@
         <td>{{command.name}}</td>
         <td>{{service.findSystem(command).version}}</td>
         <td>{{ command.description || "No Description Provided" }}</td>
-        <td><a class="btn btn-primary center-block word-wrap-button" ui-sref="command({command_id: command.id})">Make it Happen!</a></td>
+        <td>
+          <a
+            class="btn btn-primary center-block word-wrap-button"
+            ui-sref="command(service.getStateParams(command))">
+            Make it Happen!
+          </a>
+        </td>
       </tr>
     </tbody>
     </table>

--- a/brew_view/static/src/partials/landing.html
+++ b/brew_view/static/src/partials/landing.html
@@ -32,7 +32,7 @@
     <div class="panel-body" style="padding-top: 0;">
       <div>
         <button type="button" class="btn btn-primary btn-lg btn-block"
-            ng-click="exploreSystem(system.id)" style="margin-top: 10px;">
+            ng-click="exploreSystem(system)" style="margin-top: 10px;">
           Explore {{system.name}} commands
         </button>
       </div>

--- a/brew_view/static/src/partials/system_view.html
+++ b/brew_view/static/src/partials/system_view.html
@@ -31,7 +31,7 @@
           <td>{{command.name}}</td>
           <td>{{system.data.version}}</td>
           <td>{{ command.description || "No Description Provided" }}</td>
-          <td><a class="btn btn-primary center-block" ui-sref="command({command_id: command.id})">Make it Happen!</a></td>
+          <td><a class="btn btn-primary center-block" ui-sref="command(getCommandStateParams(command))">Make it Happen!</a></td>
         </tr>
       </tbody>
       </table>


### PR DESCRIPTION
This fixes beer-garden/beer-garden#98

## Route Changes
These changes only affect the UI.

* /systems/{id} => /systems/{name}/{version}
* /commands/{id} => /systems/{name}/{version}/commands/{commandName}


## Special Version Note
A special note about versions though, the {version} will either
be a conrecete version or "latest" if it is the latest of the
systems currently loaded. This commit does not break backwards
compatibility for ID routing, and thus it is still in the
routes. However, no part of the UI should be using the ID for
systems anymore.

Views Tested:

* landing
* system ID
* System Admin
* Queue Admin
* Pour it Again
* System View Page
* Command Index Page
* Command View Page

