### PR TITLE
Setting default event amq publish flag to False

### DIFF
--- a/brew_view/specification.py
+++ b/brew_view/specification.py
@@ -288,7 +288,7 @@ SPECIFICATION = {
                 'items': {
                     "enable": {
                         "type": "bool",
-                        "default": True,
+                        "default": False,
                         "description": "Publish events to RabbitMQ",
                     },
                     "exchange": {


### PR DESCRIPTION
Previously (last published version) we did not have an `enabled` flag controlling event publishing over AMQ. We used the validity of the virtual host and the exchange as a sort of combined flag. Since the exchange was not required and had no default the standard behavior was not to publish.

Now we have a dedicated `enabled` flag. But for whatever reason I combined that flag with the other two options and set the default to True. This is super confusing since it *seems* like it should be enabled, but won't actually work until you set an exchange.

This fixes that by setting the default for the `enabled` flag to False. The check to determine whether to construct the AMQ publisher was already simplified to only care about `enabled` in a prior commit.