### PR TITLE
Adding version header to all responses

### DIFF
--- a/brew_view/__init__.py
+++ b/brew_view/__init__.py
@@ -16,6 +16,7 @@ from urllib3.util.url import Url
 
 import bg_utils
 import brewtils.rest
+import brew_view._version
 from bg_utils.event_publisher import EventPublishers
 from bg_utils.models import Role
 from bg_utils.pika import TransientPikaClient
@@ -33,6 +34,8 @@ from brewtils.schemas import (
     RoleSchema, RefreshTokenSchema, JobSchema, DateTriggerSchema,
     IntervalTriggerSchema, CronTriggerSchema
 )
+
+__version__ = brew_view._version.__version__
 
 config = None
 application = None

--- a/brew_view/base_handler.py
+++ b/brew_view/base_handler.py
@@ -89,7 +89,8 @@ class BaseHandler(RequestHandler):
         }
 
     def set_default_headers(self):
-        """Enable CORS by setting the access control header"""
+        """Headers set here will be applied to all responses"""
+        self.set_header("BG-Version", brew_view.__version__)
 
         if brew_view.config.cors_enabled:
             self.set_header("Access-Control-Allow-Origin", "*")

--- a/brew_view/controllers/misc_controllers.py
+++ b/brew_view/controllers/misc_controllers.py
@@ -32,8 +32,6 @@ class VersionHandler(BaseHandler):
 
     @coroutine
     def get(self):
-        from brew_view._version import __version__
-
         with thrift_context() as client:
             try:
                 bartender_version = yield client.getVersion()
@@ -44,7 +42,7 @@ class VersionHandler(BaseHandler):
                 bartender_version = "unknown"
 
         self.write({
-            "brew_view_version": __version__,
+            "brew_view_version": brew_view.__version__,
             "bartender_version": bartender_version,
             "current_api_version": "v1",
             "supported_api_versions": ["v1"]


### PR DESCRIPTION
Fixes beer-garden/beer-garden#131

I went with `bg-version` because of the impending brew-view + bartender merger, and I used the actual brew-view version because it's easiest.