### PR TITLE
Transitioning to thriftpy2 as thriftpy is deprecated

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -70,7 +70,7 @@ snowballstemmer==1.2.1    # via sphinx
 sphinx-rtd-theme==0.4.1
 sphinx==1.7.6
 sphinxcontrib-websupport==1.1.0  # via sphinx
-thriftpy==0.3.9
+thriftpy2==0.3.11
 tornado==5.1
 tox==3.1.3
 tqdm==4.24.0              # via twine


### PR DESCRIPTION
This helps with beer-garden/beer-garden#175 (Python 3.7 support)