### PR TITLE
Using startswith for command, system, and instance field filters

### DIFF
--- a/brew_view/controllers/request_list_api.py
+++ b/brew_view/controllers/request_list_api.py
@@ -373,24 +373,36 @@ class RequestListAPI(BaseHandler):
                 if column['data']:
                     requested_fields.append(column['data'])
 
-                if 'searchable' in column and column['searchable'] and column['search']['value']:
+                if 'searchable' in column and \
+                        column['searchable'] and \
+                        column['search']['value']:
                     if column['data'] in ['created_at', 'updated_at']:
                         search_dates = column['search']['value'].split('~')
                         start_query = Q()
                         end_query = Q()
 
                         if search_dates[0]:
-                            start_query = Q(**{column['data']+'__gte': search_dates[0]})
+                            start_query = Q(**{
+                                column['data']+'__gte': search_dates[0]
+                            })
                         if search_dates[1]:
-                            end_query = Q(**{column['data']+'__lte': search_dates[1]})
+                            end_query = Q(**{
+                                column['data']+'__lte': search_dates[1]
+                            })
 
                         search_query = start_query & end_query
                     elif column['data'] == 'status':
-                        search_query = Q(**{column['data']+'__exact': column['search']['value']})
+                        search_query = Q(**{
+                            column['data']+'__exact': column['search']['value']
+                        })
                     elif column['data'] == 'comment':
-                        search_query = Q(**{column['data']+'__contains': column['search']['value']})
+                        search_query = Q(**{
+                            column['data']+'__contains': column['search']['value']
+                        })
                     else:
-                        search_query = Q(**{column['data']+'__startswith': column['search']['value']})
+                        search_query = Q(**{
+                            column['data']+'__startswith': column['search']['value']
+                        })
 
                     search_params.append(search_query)
 

--- a/brew_view/controllers/request_list_api.py
+++ b/brew_view/controllers/request_list_api.py
@@ -373,9 +373,11 @@ class RequestListAPI(BaseHandler):
                 if column['data']:
                     requested_fields.append(column['data'])
 
-                if 'searchable' in column and \
-                        column['searchable'] and \
-                        column['search']['value']:
+                if (
+                        'searchable' in column
+                        and column['searchable']
+                        and column['search']['value']
+                ):
                     if column['data'] in ['created_at', 'updated_at']:
                         search_dates = column['search']['value'].split('~')
                         start_query = Q()

--- a/test/unit/controllers/request_list_api_test.py
+++ b/test/unit/controllers/request_list_api_test.py
@@ -36,9 +36,12 @@ class RequestListAPITest(TestHandlerBase):
 
         super(RequestListAPITest, self).setUp()
 
-    @patch('brew_view.controllers.request_list_api.RequestListAPI._get_requests')
-    def test_get(self, get_requests_mock):
-        get_requests_mock.return_value = (['request'], 1, None)
+    @patch('brew_view.controllers.request_list_api.RequestListAPI._get_query_set')
+    def test_get(self, get_query_set_mock):
+        query_set = MagicMock()
+        query_set.count.return_value = 1
+        query_set.__getitem__ = lambda *_: ['request']
+        get_query_set_mock.return_value = (query_set, None)
 
         response = self.fetch('/api/v1/requests?draw=1')
         self.assertEqual(200, response.code)


### PR DESCRIPTION
This mostly fixes beer-garden/beer-garden#104 and is part of the mongo performance push.

This PR changes the filtering behavior in these ways:

- Comment, Created & Search does not change (`contains`)
- Status filter is an exact match (`exact`)
- Command Name, System, and Instance filters now search from the beginning (`startswith`)

104 says that it would be nice to allow searching the old way as well. Basically allow the user to search using regular expressions. The issue there is that in order to take advantage of the mongo indexes we can't use regular expressions (since that forces mongo to examine every document). So we'd need some way to distinguish between "this is a regex filter" and "this is a normal startswith filter." We could *sort of* determine this by inspecting the filter and looking for regex characters, but that's pretty brittle. It feels like we'd almost need something in the UI to toggle filter types.

I think that's way too involved to do right now, and I'm assuming that most people are already using the filters in a way that will still work with these changes.

@loganasherjones thoughts?