### PR TITLE
Auth update

### DIFF
--- a/brew_view/__init__.py
+++ b/brew_view/__init__.py
@@ -105,6 +105,7 @@ def startup():
     yield _progressive_backoff(
         partial(setup_database, config), "Unable to connect to mongo, is it started?"
     )
+    anonymous_principal = load_anonymous()
 
     # Need to wait until after mongo connection established to load
     anonymous_principal = load_anonymous()

--- a/brew_view/__init__.py
+++ b/brew_view/__init__.py
@@ -103,8 +103,7 @@ def startup():
     # Ensure we have a mongo connection
     logger.info("Checking for Mongo connection")
     yield _progressive_backoff(
-        partial(setup_database, config, {"brew_view_version": __version__}),
-        "Unable to connect to mongo, is it started?",
+        partial(setup_database, config), "Unable to connect to mongo, is it started?"
     )
     anonymous_principal = load_anonymous()
 

--- a/brew_view/__init__.py
+++ b/brew_view/__init__.py
@@ -103,7 +103,8 @@ def startup():
     # Ensure we have a mongo connection
     logger.info("Checking for Mongo connection")
     yield _progressive_backoff(
-        partial(setup_database, config), "Unable to connect to mongo, is it started?"
+        partial(setup_database, config, {"brew_view_version": __version__}),
+        "Unable to connect to mongo, is it started?"
     )
     anonymous_principal = load_anonymous()
 

--- a/brew_view/__init__.py
+++ b/brew_view/__init__.py
@@ -104,7 +104,7 @@ def startup():
     logger.info("Checking for Mongo connection")
     yield _progressive_backoff(
         partial(setup_database, config, {"brew_view_version": __version__}),
-        "Unable to connect to mongo, is it started?"
+        "Unable to connect to mongo, is it started?",
     )
     anonymous_principal = load_anonymous()
 
@@ -339,7 +339,9 @@ def _setup_tornado_app():
     _load_swagger(published_url_specs, title=config.application.name)
 
     return Application(
-        published_url_specs + unpublished_url_specs, debug=config.debug_mode
+        published_url_specs + unpublished_url_specs,
+        debug=config.debug_mode,
+        cookie_secret=config.auth.token.secret,
     )
 
 

--- a/brew_view/__init__.py
+++ b/brew_view/__init__.py
@@ -105,7 +105,6 @@ def startup():
     yield _progressive_backoff(
         partial(setup_database, config), "Unable to connect to mongo, is it started?"
     )
-    anonymous_principal = load_anonymous()
 
     # Need to wait until after mongo connection established to load
     anonymous_principal = load_anonymous()

--- a/brew_view/authorization.py
+++ b/brew_view/authorization.py
@@ -126,8 +126,12 @@ def anonymous_principal():
     without having to calculate effective permissions every time.
     """
 
-    if brew_view.config.auth.enabled:
+    if brew_view.config.auth.enabled and brew_view.config.auth.guest_login_enabled:
         roles = Principal.objects.get(username="anonymous").roles
+    elif brew_view.config.auth.enabled:
+        # By default, if no guest login is available, there is no anonymous
+        # user, which means there are no roles.
+        roles = []
     else:
         roles = [Role(name="bg-admin", permissions=["bg-all"])]
 

--- a/brew_view/authorization.py
+++ b/brew_view/authorization.py
@@ -5,7 +5,7 @@ import jwt
 import wrapt
 from mongoengine.errors import DoesNotExist
 from passlib.apps import custom_app_context
-from tornado.web import HTTPError
+from tornado.web import HTTPError, decode_signed_value
 
 import brew_view
 from bg_utils.mongo.models import Principal, Role

--- a/brew_view/authorization.py
+++ b/brew_view/authorization.py
@@ -5,7 +5,7 @@ import jwt
 import wrapt
 from mongoengine.errors import DoesNotExist
 from passlib.apps import custom_app_context
-from tornado.web import HTTPError, decode_signed_value
+from tornado.web import HTTPError
 
 import brew_view
 from bg_utils.mongo.models import Principal, Role

--- a/brew_view/base_handler.py
+++ b/brew_view/base_handler.py
@@ -60,7 +60,7 @@ class BaseHandler(AuthMixin, RequestHandler):
         refresh_id = self.get_secure_cookie(self.REFRESH_COOKIE_NAME)
         token = bg_utils.mongo.models.RefreshToken.objects.get(id=refresh_id)
         now = datetime.datetime.utcnow()
-        if not token or token.expires > now:
+        if not token or token.expires < now:
             return None
 
         principal = token.get_principal()

--- a/brew_view/base_handler.py
+++ b/brew_view/base_handler.py
@@ -14,7 +14,7 @@ from tornado.web import HTTPError, RequestHandler
 import bg_utils
 import bg_utils.mongo.models
 import brew_view
-from brew_view.authorization import AuthMixin
+from brew_view.authorization import AuthMixin, coalesce_permissions
 from brew_view.metrics import http_api_latency_total, request_latency
 from brewtils.errors import (
     ModelError,
@@ -67,7 +67,8 @@ class BaseHandler(AuthMixin, RequestHandler):
         if not principal:
             return None
 
-        token.expires = now + datetime.timedelta(hours=24 * self.REFRESH_COOKIE_EXP)
+        _, principal.permissions = coalesce_permissions(principal.roles)
+        token.expires = now + datetime.timedelta(days=self.REFRESH_COOKIE_EXP)
         token.save()
         return principal
 

--- a/brew_view/controllers/misc_controllers.py
+++ b/brew_view/controllers/misc_controllers.py
@@ -4,19 +4,21 @@ from tornado.gen import coroutine
 
 import brew_view
 from bg_utils.mongo.models import AppState
-from bg_utils.mongo.parser import BeerGardenSchemaParser
+from bg_utils.mongo.parser import MongoParser
 from brew_view import thrift_context
 from brew_view.base_handler import BaseHandler
 
 
 class ConfigHandler(BaseHandler):
 
-    parser = BeerGardenSchemaParser()
+    parser = MongoParser()
 
     def get(self):
         """Subset of configuration options that the frontend needs"""
         app_state = AppState.objects.first()
-        serialized_app_state = self.parser.serialize_app_state(app_state, to_string=False)
+        serialized_app_state = self.parser.serialize_app_state(
+            app_state, to_string=False
+        )
         configs = {
             "allow_unsafe_templates": brew_view.config.application.allow_unsafe_templates,
             "application_name": brew_view.config.application.name,

--- a/brew_view/controllers/misc_controllers.py
+++ b/brew_view/controllers/misc_controllers.py
@@ -42,14 +42,14 @@ class ConfigHandler(BaseHandler):
 class VersionHandler(BaseHandler):
     @coroutine
     def get(self):
-        with thrift_context() as client:
-            try:
+        try:
+            with thrift_context() as client:
                 bartender_version = yield client.getVersion()
-            except Exception as ex:
-                logger = logging.getLogger(__name__)
-                logger.error("Could not get Bartender Version.")
-                logger.exception(ex)
-                bartender_version = "unknown"
+        except Exception as ex:
+            logger = logging.getLogger(__name__)
+            logger.error("Could not get Bartender Version.")
+            logger.exception(ex)
+            bartender_version = "unknown"
 
         self.write(
             {

--- a/brew_view/controllers/misc_controllers.py
+++ b/brew_view/controllers/misc_controllers.py
@@ -3,7 +3,6 @@ import logging
 from tornado.gen import coroutine
 
 import brew_view
-# from bg_utils.mongo.models import AppState
 from bg_utils.mongo.parser import MongoParser
 from brew_view import thrift_context
 from brew_view.base_handler import BaseHandler
@@ -15,10 +14,6 @@ class ConfigHandler(BaseHandler):
 
     def get(self):
         """Subset of configuration options that the frontend needs"""
-        # app_state = AppState.objects.first()
-        # serialized_app_state = self.parser.serialize_app_state(
-        #     app_state, to_string=False
-        # )
         configs = {
             "allow_unsafe_templates": brew_view.config.application.allow_unsafe_templates,
             "application_name": brew_view.config.application.name,
@@ -34,7 +29,6 @@ class ConfigHandler(BaseHandler):
             "metrics_url": brew_view.config.metrics.url,
             "auth_enabled": brew_view.config.auth.enabled,
             "guest_login_enabled": brew_view.config.auth.guest_login_enabled,
-            # "app_state": serialized_app_state,
         }
         self.write(configs)
 

--- a/brew_view/controllers/misc_controllers.py
+++ b/brew_view/controllers/misc_controllers.py
@@ -3,13 +3,20 @@ import logging
 from tornado.gen import coroutine
 
 import brew_view
+from bg_utils.mongo.models import AppState
+from bg_utils.mongo.parser import BeerGardenSchemaParser
 from brew_view import thrift_context
 from brew_view.base_handler import BaseHandler
 
 
 class ConfigHandler(BaseHandler):
+
+    parser = BeerGardenSchemaParser()
+
     def get(self):
         """Subset of configuration options that the frontend needs"""
+        app_state = AppState.objects.first()
+        serialized_app_state = self.parser.serialize_app_state(app_state, to_string=False)
         configs = {
             "allow_unsafe_templates": brew_view.config.application.allow_unsafe_templates,
             "application_name": brew_view.config.application.name,
@@ -24,6 +31,8 @@ class ConfigHandler(BaseHandler):
             "url_prefix": brew_view.config.web.url_prefix,
             "metrics_url": brew_view.config.metrics.url,
             "auth_enabled": brew_view.config.auth.enabled,
+            "guest_login_enabled": brew_view.config.auth.guest_login_enabled,
+            "app_state": serialized_app_state,
         }
         self.write(configs)
 

--- a/brew_view/controllers/misc_controllers.py
+++ b/brew_view/controllers/misc_controllers.py
@@ -3,7 +3,7 @@ import logging
 from tornado.gen import coroutine
 
 import brew_view
-from bg_utils.mongo.models import AppState
+# from bg_utils.mongo.models import AppState
 from bg_utils.mongo.parser import MongoParser
 from brew_view import thrift_context
 from brew_view.base_handler import BaseHandler
@@ -15,10 +15,10 @@ class ConfigHandler(BaseHandler):
 
     def get(self):
         """Subset of configuration options that the frontend needs"""
-        app_state = AppState.objects.first()
-        serialized_app_state = self.parser.serialize_app_state(
-            app_state, to_string=False
-        )
+        # app_state = AppState.objects.first()
+        # serialized_app_state = self.parser.serialize_app_state(
+        #     app_state, to_string=False
+        # )
         configs = {
             "allow_unsafe_templates": brew_view.config.application.allow_unsafe_templates,
             "application_name": brew_view.config.application.name,
@@ -34,7 +34,7 @@ class ConfigHandler(BaseHandler):
             "metrics_url": brew_view.config.metrics.url,
             "auth_enabled": brew_view.config.auth.enabled,
             "guest_login_enabled": brew_view.config.auth.guest_login_enabled,
-            "app_state": serialized_app_state,
+            # "app_state": serialized_app_state,
         }
         self.write(configs)
 

--- a/brew_view/controllers/misc_controllers.py
+++ b/brew_view/controllers/misc_controllers.py
@@ -3,14 +3,11 @@ import logging
 from tornado.gen import coroutine
 
 import brew_view
-from bg_utils.mongo.parser import MongoParser
 from brew_view import thrift_context
 from brew_view.base_handler import BaseHandler
 
 
 class ConfigHandler(BaseHandler):
-
-    parser = MongoParser()
 
     def get(self):
         """Subset of configuration options that the frontend needs"""

--- a/brew_view/controllers/roles_api.py
+++ b/brew_view/controllers/roles_api.py
@@ -161,6 +161,13 @@ class RoleAPI(BaseHandler):
                 except DoesNotExist:
                     raise ModelValidationError("Role '%s' does not exist" % op.value)
 
+            elif op.path == "/description":
+                if op.operation != "update":
+                    raise ModelValidationError(
+                        "Unsupported operation '%s'" % op.operation
+                    )
+                role.description = op.value
+
             else:
                 raise ModelValidationError("Unsupported path '%s'" % op.path)
 

--- a/brew_view/controllers/token_api.py
+++ b/brew_view/controllers/token_api.py
@@ -244,6 +244,15 @@ class TokenListAPI(BaseHandler):
 
             if verified:
                 tokens = generate_tokens(principal, self.REFRESH_COOKIE_EXP)
+
+                # This is a semi-done solution. To really do this, we cannot give them
+                # a token, instead we should return an error, indicating they need to
+                # update their password, and then login again. In the short term, this
+                # will be enough. This is really meant only to work for our UI so
+                # backwards compatibility is not a concern.
+                if principal.metadata.get('auto_change') and not principal.metadata.get('changed'):
+                    self.set_header('change_password_required', 'true')
+
                 if parsed_body.get("remember_me", False):
                     self.set_secure_cookie(
                         self.REFRESH_COOKIE_NAME,

--- a/brew_view/controllers/token_api.py
+++ b/brew_view/controllers/token_api.py
@@ -108,8 +108,8 @@ class TokenListAPI(BaseHandler):
         summary: Use a refresh token to retrieve a new access token
         description: |
           Your refresh token can either be set in a cookie (which we set on your
-          session when you logged in) or you can include a JSON payload in the request
-          body, which specified "refresh_id"
+          session when you logged in) or you can include the refresh ID as a
+          header named "X-BG-RefreshID"
         responses:
           200:
             description: New Auth Token
@@ -189,9 +189,8 @@ class TokenListAPI(BaseHandler):
         summary: Remove a refresh token
         description: |
           Your refresh token can either be set in a cookie (which we set on your
-          session when you logged in) or you can include a JSON payload in the request
-          body, which specified "refresh_id". This will delete this particular
-          refresh token if it exists.
+          session when you logged in) or you can include the refresh ID as a
+          header named "X-BG-RefreshID"
         responses:
           204:
             description: Token has been successfully deleted
@@ -273,14 +272,8 @@ class TokenListAPI(BaseHandler):
         if not token_id:
             token_id = self.get_refresh_id_from_cookie()
 
-        if not token_id and self.request.body:
-            body = self.request.body.decode("utf-8")
-            try:
-                json_body = json.loads(body)
-                if "refresh_id" in json_body:
-                    token_id = json_body["refresh_id"]
-            except (TypeError, ValueError):
-                pass
+        if not token_id and self.request.headers:
+            token_id = self.request.headers.get("X-BG-RefreshID", None)
 
         if token_id:
             try:

--- a/brew_view/controllers/token_api.py
+++ b/brew_view/controllers/token_api.py
@@ -250,8 +250,10 @@ class TokenListAPI(BaseHandler):
                 # update their password, and then login again. In the short term, this
                 # will be enough. This is really meant only to work for our UI so
                 # backwards compatibility is not a concern.
-                if principal.metadata.get('auto_change') and not principal.metadata.get('changed'):
-                    self.set_header('change_password_required', 'true')
+                if principal.metadata.get("auto_change") and not principal.metadata.get(
+                    "changed"
+                ):
+                    self.set_header("change_password_required", "true")
 
                 if parsed_body.get("remember_me", False):
                     self.set_secure_cookie(

--- a/brew_view/controllers/users_api.py
+++ b/brew_view/controllers/users_api.py
@@ -14,7 +14,7 @@ from brew_view.authorization import (
     coalesce_permissions,
 )
 from brew_view.base_handler import BaseHandler
-from brewtils.errors import ModelValidationError
+from brewtils.errors import ModelValidationError, RequestForbidden
 
 
 class UserAPI(BaseHandler):
@@ -153,6 +153,47 @@ class UserAPI(BaseHandler):
                 except DoesNotExist:
                     raise ModelValidationError("Role '%s' does not exist" % op.value)
 
+            elif op.path == "/username":
+                if user_id != self.current_user.id:
+                    check_permission(self.current_user, [Permissions.USER_UPDATE])
+
+                if op.operation == "update":
+                    principal.username = op.value
+                else:
+                    raise ModelValidationError(
+                        "Unsupported operation '%s'" % op.operation
+                    )
+
+            elif op.path == "/password":
+                if op.operation != "update":
+                    raise ModelValidationError(
+                        "Unsupported operation '%s'" % op.operation
+                    )
+
+                if isinstance(op.value, dict):
+                    current_password = op.value.get("current_password")
+                    new_password = op.value.get("new_password")
+                else:
+                    current_password = None
+                    new_password = op.value
+
+                if user_id == self.current_user.id:
+                    if current_password is None:
+                        raise ModelValidationError(
+                            "In order to update your own password, you must provide "
+                            "your current password"
+                        )
+
+                    if not custom_app_context.verify(
+                        current_password, self.current_user.hash
+                    ):
+                        raise RequestForbidden("Invalid password")
+
+                else:
+                    check_permission(self.current_user, [Permissions.USER_UPDATE])
+
+                principal.hash = custom_app_context.hash(new_password)
+
             elif op.path == "/preferences/theme":
                 if user_id != self.current_user.id:
                     check_permission(self.current_user, [Permissions.USER_UPDATE])
@@ -170,6 +211,7 @@ class UserAPI(BaseHandler):
 
         principal.save()
 
+        principal.permissions = coalesce_permissions(principal.roles)[1]
         self.write(MongoParser.serialize_principal(principal, to_string=False))
 
 
@@ -242,6 +284,12 @@ class UsersAPI(BaseHandler):
             username=parsed["username"],
             hash=custom_app_context.hash(parsed["password"]),
         )
-        user.save()
 
-        self.set_status(204)
+        if "roles" in parsed:
+            user.roles = [Role.objects.get(name=name) for name in parsed["roles"]]
+
+        user.save()
+        user.permissions = coalesce_permissions(user.roles)[1]
+
+        self.set_status(201)
+        self.write(MongoParser.serialize_principal(user, to_string=False))

--- a/brew_view/controllers/users_api.py
+++ b/brew_view/controllers/users_api.py
@@ -48,7 +48,7 @@ class UserAPI(BaseHandler):
         else:
             # Need fine-grained access control here
             if user_identifier not in [
-                self.current_user.id,
+                str(self.current_user.id),
                 self.current_user.username,
             ]:
                 check_permission(self.current_user, [Permissions.USER_READ])
@@ -154,7 +154,7 @@ class UserAPI(BaseHandler):
                     raise ModelValidationError("Role '%s' does not exist" % op.value)
 
             elif op.path == "/username":
-                if user_id != self.current_user.id:
+                if user_id != str(self.current_user.id):
                     check_permission(self.current_user, [Permissions.USER_UPDATE])
 
                 if op.operation == "update":
@@ -177,7 +177,7 @@ class UserAPI(BaseHandler):
                     current_password = None
                     new_password = op.value
 
-                if user_id == self.current_user.id:
+                if user_id == str(self.current_user.id):
                     if current_password is None:
                         raise ModelValidationError(
                             "In order to update your own password, you must provide "
@@ -195,7 +195,7 @@ class UserAPI(BaseHandler):
                 principal.hash = custom_app_context.hash(new_password)
 
             elif op.path == "/preferences/theme":
-                if user_id != self.current_user.id:
+                if user_id != str(self.current_user.id):
                     check_permission(self.current_user, [Permissions.USER_UPDATE])
 
                 if op.operation == "set":

--- a/brew_view/controllers/users_api.py
+++ b/brew_view/controllers/users_api.py
@@ -193,6 +193,8 @@ class UserAPI(BaseHandler):
                     check_permission(self.current_user, [Permissions.USER_UPDATE])
 
                 principal.hash = custom_app_context.hash(new_password)
+                if "changed" in principal.metadata:
+                    principal.metadata["changed"] = True
 
             elif op.path == "/preferences/theme":
                 if user_id != str(self.current_user.id):

--- a/brew_view/specification.py
+++ b/brew_view/specification.py
@@ -190,8 +190,8 @@ SPECIFICATION = {
                 "type": "bool",
                 "default": True,
                 "description": "Only applicable if auth is enabled. If set to "
-                               "true, guests can login without username/"
-                               "passwords."
+                "true, guests can login without username/"
+                "passwords.",
             },
             "token": {
                 "type": "dict",

--- a/brew_view/specification.py
+++ b/brew_view/specification.py
@@ -186,6 +186,13 @@ SPECIFICATION = {
                 "default": False,
                 "description": "Use role-based authentication / authorization",
             },
+            "guest_login_enabled": {
+                "type": "bool",
+                "default": True,
+                "description": "Only applicable if auth is enabled. If set to "
+                               "true, guests can login without username/"
+                               "passwords."
+            },
             "token": {
                 "type": "dict",
                 "items": {

--- a/dev_conf/config.yaml
+++ b/dev_conf/config.yaml
@@ -23,7 +23,8 @@ application:
   icon_default: fa-beer
   name: Beer Garden
 auth:
-  enabled: false
+  enabled: true
+  guest_login_enabled: false
   token:
     algorithm: HS256
     lifetime: 1200

--- a/dev_conf/config.yaml
+++ b/dev_conf/config.yaml
@@ -24,7 +24,7 @@ application:
   name: Beer Garden
 auth:
   enabled: true
-  guest_login_enabled: false
+  guest_login_enabled: true
   token:
     algorithm: HS256
     lifetime: 1200

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -4,6 +4,7 @@ from mongoengine import connect
 
 import brew_view
 import brewtils.test
+from bg_utils.mongo.parser import MongoParser
 from brew_view.authorization import anonymous_principal
 from test.utils import brew2mongo
 
@@ -76,3 +77,17 @@ def mongo_system(bg_system):
 @pytest.fixture
 def mongo_job(bg_job):
     return brew2mongo(bg_job)
+
+
+@pytest.fixture
+def mongo_principal(principal_dict):
+    principal = principal_dict.copy()
+    del principal['permissions']
+    return MongoParser().parse_principal(principal, False)
+
+
+@pytest.fixture
+def mongo_role(role_dict):
+    role = role_dict.copy()
+    role['roles'] = []
+    return MongoParser().parse_role(role, False)

--- a/test/unit/controllers/misc_controller_test.py
+++ b/test/unit/controllers/misc_controller_test.py
@@ -12,8 +12,11 @@ class ConfigHandlerTest(TestHandlerBase):
         import brew_view
 
         brew_view.config["application"]["name"] = "Rock Garden"
-
         response = self.fetch("/config")
+        data = json.loads(response.body.decode("utf-8"))
+        self.assertEqual("Rock Garden", data["application_name"])
+        assert "app_state" in data
+
         self.assertEqual(
             "Rock Garden", json.loads(response.body.decode("utf-8"))["application_name"]
         )

--- a/test/unit/controllers/misc_controller_test.py
+++ b/test/unit/controllers/misc_controller_test.py
@@ -15,7 +15,6 @@ class ConfigHandlerTest(TestHandlerBase):
         response = self.fetch("/config")
         data = json.loads(response.body.decode("utf-8"))
         self.assertEqual("Rock Garden", data["application_name"])
-        assert "app_state" in data
 
         self.assertEqual(
             "Rock Garden", json.loads(response.body.decode("utf-8"))["application_name"]

--- a/test/unit/controllers/misc_controller_test.py
+++ b/test/unit/controllers/misc_controller_test.py
@@ -70,3 +70,21 @@ class VersionHandlerTest(TestHandlerBase):
                 "supported_api_versions": ["v1"],
             },
         )
+
+    @patch("brew_view.controllers.misc_controllers.thrift_context")
+    def test_version_fail_to_get_thrift_context(self, context_mock):
+        context_mock.side_effect = ValueError("cant connect")
+        self.client_mock.getVersion.return_value = self.future_mock
+        self.future_mock.set_exception(ValueError("cant connect"))
+
+        response = self.fetch("/version")
+        output = json.loads(response.body.decode("utf-8"))
+        self.assertEqual(
+            output,
+            {
+                "brew_view_version": __version__,
+                "bartender_version": "unknown",
+                "current_api_version": "v1",
+                "supported_api_versions": ["v1"],
+            },
+        )

--- a/test/unit/controllers/roles_api_test.py
+++ b/test/unit/controllers/roles_api_test.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+import json
+
+import pytest
+from tornado.httpclient import HTTPRequest
+
+from bg_utils.mongo.models import Role
+from brewtils.models import PatchOperation
+from brewtils.schema_parser import SchemaParser
+
+
+@pytest.fixture(autouse=True)
+def drop_roles(app):
+    Role.drop_collection()
+
+
+class TestRolesAPI(object):
+    @pytest.mark.gen_test
+    @pytest.mark.parametrize(
+        "operation,value,expected_value,succeed",
+        [
+            ("update", "new_description", "new_description", True),
+            ("INVALID", None, None, False),
+        ],
+    )
+    def test_patch_role_description(
+            self,
+            http_client,
+            base_url,
+            mongo_role,
+            operation,
+            value,
+            expected_value,
+            succeed,
+    ):
+        mongo_role.save()
+
+        body = PatchOperation(operation=operation, path="/description", value=value)
+
+        request = HTTPRequest(
+            base_url + "/api/v1/roles/" + str(mongo_role.id),
+            method="PATCH",
+            headers={"content-type": "application/json"},
+            body=SchemaParser.serialize_patch(body),
+            )
+        response = yield http_client.fetch(request, raise_error=False)
+
+        if succeed:
+            assert response.code == 200
+            updated = SchemaParser.parse_role(
+                response.body.decode("utf-8"), from_string=True
+            )
+            assert updated.description == expected_value
+
+        else:
+            assert response.code >= 400

--- a/test/unit/controllers/roles_api_test.py
+++ b/test/unit/controllers/roles_api_test.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-import json
-
 import pytest
 from tornado.httpclient import HTTPRequest
 
@@ -24,14 +22,14 @@ class TestRolesAPI(object):
         ],
     )
     def test_patch_role_description(
-            self,
-            http_client,
-            base_url,
-            mongo_role,
-            operation,
-            value,
-            expected_value,
-            succeed,
+        self,
+        http_client,
+        base_url,
+        mongo_role,
+        operation,
+        value,
+        expected_value,
+        succeed,
     ):
         mongo_role.save()
 
@@ -42,7 +40,7 @@ class TestRolesAPI(object):
             method="PATCH",
             headers={"content-type": "application/json"},
             body=SchemaParser.serialize_patch(body),
-            )
+        )
         response = yield http_client.fetch(request, raise_error=False)
 
         if succeed:

--- a/test/unit/controllers/token_api_test.py
+++ b/test/unit/controllers/token_api_test.py
@@ -1,0 +1,190 @@
+import copy
+import datetime
+import json
+
+from mock import Mock, patch
+
+from bg_utils.mongo.models import RefreshToken
+from . import TestHandlerBase
+
+
+class TokenAPITest(TestHandlerBase):
+    def setUp(self):
+        self.refresh_dict = {
+            "issued": datetime.datetime.utcnow(),
+            "expires": datetime.datetime.utcnow() + datetime.timedelta(days=1),
+            "payload": {"sub": "USER_ID_HERE"},
+        }
+
+        db_dict = copy.deepcopy(self.refresh_dict)
+        self.refresh = RefreshToken(**db_dict)
+
+        super(TokenAPITest, self).setUp()
+
+    def tearDown(self):
+        RefreshToken.objects.delete()
+
+    def test_old_refresh(self):
+        self.refresh.save()
+        response = self.fetch("/api/v1/tokens/" + str(self.refresh.id))
+        self.assertEqual(200, response.code)
+        data = json.loads(response.body.decode("utf-8"))
+        assert "token" in data
+
+    def test_old_refresh_not_found(self):
+        response = self.fetch("/api/v1/tokens/" + "222222222222222222222222")
+        self.assertEqual(403, response.code)
+
+    def test_old_delete(self):
+        self.refresh.save()
+        response = self.fetch("/api/v1/tokens/" + str(self.refresh.id), method="DELETE")
+        self.assertEqual(204, response.code)
+
+    @patch("brew_view.base_handler.BaseHandler.get_secure_cookie")
+    def test_get_no_refresh_token(self, get_cookie_mock):
+        get_cookie_mock.return_value = None
+        response = self.fetch("/api/v1/tokens")
+        self.assertEqual(403, response.code)
+
+    @patch("brew_view.base_handler.BaseHandler.get_secure_cookie")
+    def test_get_invalid_request_body(self, get_cookie_mock):
+        get_cookie_mock.return_value = None
+        response = self.fetch(
+            "/api/v1/tokens",
+            method="GET",
+            body="some garbage here.",
+            headers={"content-type": "application/json"},
+            allow_nonstandard_methods=True,
+        )
+        self.assertEqual(403, response.code)
+
+    @patch("brew_view.base_handler.BaseHandler.get_secure_cookie")
+    def test_get_invalid_refresh_cookie(self, get_cookie_mock):
+        get_cookie_mock.return_value = Mock(
+            decode=Mock(return_value="222222222222222222222222")
+        )
+        response = self.fetch("/api/v1/tokens")
+        self.assertEqual(403, response.code)
+
+    @patch("brew_view.base_handler.BaseHandler.get_secure_cookie")
+    def test_get_refresh_token_expired(self, get_cookie_mock):
+        self.refresh.expires = datetime.datetime.utcnow() - datetime.timedelta(days=1)
+        self.refresh.save()
+        get_cookie_mock.return_value = Mock(decode=Mock(return_value=self.refresh.id))
+        response = self.fetch("/api/v1/tokens")
+        self.assertEqual(403, response.code)
+
+    @patch("brew_view.base_handler.BaseHandler.get_secure_cookie")
+    def test_get_refresh_token_cookie(self, get_cookie_mock):
+        self.refresh.save()
+        get_cookie_mock.return_value = Mock(decode=Mock(return_value=self.refresh.id))
+        response = self.fetch("/api/v1/tokens")
+        self.assertEqual(200, response.code)
+        data = json.loads(response.body.decode("utf-8"))
+        assert "token" in data
+
+    @patch("brew_view.base_handler.BaseHandler.get_secure_cookie")
+    def test_get_refresh_token_payload(self, get_cookie_mock):
+        self.refresh.save()
+        get_cookie_mock.return_value = None
+        response = self.fetch(
+            "/api/v1/tokens",
+            method="GET",
+            body=json.dumps({"refresh_id": str(self.refresh.id)}),
+            headers={"content-type": "application/json"},
+            allow_nonstandard_methods=True,
+        )
+        self.assertEqual(200, response.code)
+        data = json.loads(response.body.decode("utf-8"))
+        assert "token" in data
+
+    def test_patch_noop(self):
+        body = "[]"
+        response = self.fetch(
+            "/api/v1/tokens",
+            method="PATCH",
+            body=body,
+            headers={"content-type": "application/json"},
+        )
+        self.assertEqual(200, response.code)
+        data = json.loads(response.body.decode("utf-8"))
+        self.assertEqual(data, None)
+
+    def test_patch_bad_operation(self):
+        self.refresh.save()
+        body = json.dumps(
+            {
+                "operations": [
+                    {
+                        "operation": "INVALID",
+                        "path": "/payload",
+                        "value": str(self.refresh.id),
+                    }
+                ]
+            }
+        )
+        response = self.fetch(
+            "/api/v1/tokens",
+            method="PATCH",
+            body=body,
+            headers={"content-type": "application/json"},
+        )
+        self.assertEqual(400, response.code)
+
+    def test_patch_bad_path(self):
+        self.refresh.save()
+        body = json.dumps(
+            {
+                "operations": [
+                    {
+                        "operation": "refresh",
+                        "path": "/INVALID",
+                        "value": str(self.refresh.id),
+                    }
+                ]
+            }
+        )
+        response = self.fetch(
+            "/api/v1/tokens",
+            method="PATCH",
+            body=body,
+            headers={"content-type": "application/json"},
+        )
+        self.assertEqual(400, response.code)
+
+    def test_patch_with_value(self):
+        self.refresh.save()
+        body = json.dumps(
+            {
+                "operations": [
+                    {
+                        "operation": "refresh",
+                        "path": "/payload",
+                        "value": str(self.refresh.id),
+                    }
+                ]
+            }
+        )
+        response = self.fetch(
+            "/api/v1/tokens",
+            method="PATCH",
+            body=body,
+            headers={"content-type": "application/json"},
+        )
+        self.assertEqual(200, response.code)
+        data = json.loads(response.body.decode("utf-8"))
+        assert "token" in data
+
+    def test_delete_no_token(self):
+        response = self.fetch("/api/v1/tokens", method="DELETE")
+        self.assertEqual(403, response.code)
+
+    @patch("brew_view.base_handler.BaseHandler.get_secure_cookie")
+    def test_delete_cookie(self, get_cookie_mock):
+        self.refresh.save()
+        get_cookie_mock.return_value = Mock(
+            decode=Mock(return_value=str(self.refresh.id))
+        )
+        response = self.fetch("/api/v1/tokens", method="DELETE")
+        self.assertEqual(204, response.code)
+        self.assertEqual(RefreshToken.objects.count(), 0)

--- a/test/unit/controllers/token_api_test.py
+++ b/test/unit/controllers/token_api_test.py
@@ -84,14 +84,16 @@ class TokenAPITest(TestHandlerBase):
         assert "token" in data
 
     @patch("brew_view.base_handler.BaseHandler.get_secure_cookie")
-    def test_get_refresh_token_payload(self, get_cookie_mock):
+    def test_get_refresh_token_header(self, get_cookie_mock):
         self.refresh.save()
         get_cookie_mock.return_value = None
         response = self.fetch(
             "/api/v1/tokens",
             method="GET",
-            body=json.dumps({"refresh_id": str(self.refresh.id)}),
-            headers={"content-type": "application/json"},
+            headers={
+                "content-type": "application/json",
+                "X-BG-RefreshID": str(self.refresh.id),
+            },
             allow_nonstandard_methods=True,
         )
         self.assertEqual(200, response.code)

--- a/test/unit/controllers/users_api_test.py
+++ b/test/unit/controllers/users_api_test.py
@@ -23,43 +23,39 @@ class TestPrincipalAPI(object):
         url = base_url + "/api/v1/users/" + str(mongo_principal.id)
         response = yield http_client.fetch(url)
         assert 200 == response.code
-        response_principal = json.loads(response.body.decode('utf-8'))
-        assert response_principal['id'] == str(mongo_principal.id)
+        response_principal = json.loads(response.body.decode("utf-8"))
+        assert response_principal["id"] == str(mongo_principal.id)
 
     @pytest.mark.gen_test
     @pytest.mark.parametrize(
         "operation,value,expected_username,succeed",
         [
-            ('update', 'new_username', 'new_username', True),
-            ('INVALID', None, None, False),
+            ("update", "new_username", "new_username", True),
+            ("INVALID", None, None, False),
         ],
     )
     def test_patch_users_username(
-            self,
-            http_client,
-            base_url,
-            mongo_principal,
-            mongo_role,
-            operation,
-            value,
-            expected_username,
-            succeed,
+        self,
+        http_client,
+        base_url,
+        mongo_principal,
+        mongo_role,
+        operation,
+        value,
+        expected_username,
+        succeed,
     ):
         mongo_role.save()
         mongo_principal.save()
 
-        body = PatchOperation(
-            operation=operation,
-            path='/username',
-            value=value,
-        )
+        body = PatchOperation(operation=operation, path="/username", value=value)
 
         request = HTTPRequest(
             base_url + "/api/v1/users/" + str(mongo_principal.id),
             method="PATCH",
             headers={"content-type": "application/json"},
             body=SchemaParser.serialize_patch(body),
-            )
+        )
         response = yield http_client.fetch(request, raise_error=False)
 
         if succeed:
@@ -72,3 +68,167 @@ class TestPrincipalAPI(object):
         else:
             assert response.code >= 400
 
+    @pytest.mark.gen_test
+    def test_patch_add_role(self, http_client, base_url, mongo_principal, mongo_role):
+        mongo_role.save()
+        mongo_principal.save()
+        new_role = Role(
+            name="new_role", description="Some desc", roles=[], permissions=["bg-all"]
+        )
+        new_role.save()
+
+        body = PatchOperation(operation="add", path="/roles", value="new_role")
+
+        url = base_url + "/api/v1/users/" + str(mongo_principal.id)
+        request = HTTPRequest(
+            url,
+            method="PATCH",
+            headers={"content-type": "application/json"},
+            body=SchemaParser.serialize_patch(body),
+        )
+        response = yield http_client.fetch(request, raise_error=False)
+
+        assert response.code == 200
+        updated = SchemaParser.parse_principal(
+            response.body.decode("utf-8"), from_string=True
+        )
+        assert len(updated.roles) == 2
+
+    @pytest.mark.gen_test
+    def test_patch_remove_role(
+        self, http_client, base_url, mongo_principal, mongo_role
+    ):
+        mongo_role.save()
+        mongo_principal.save()
+        body = PatchOperation(operation="remove", path="/roles", value=mongo_role.name)
+
+        url = base_url + "/api/v1/users/" + str(mongo_principal.id)
+        request = HTTPRequest(
+            url,
+            method="PATCH",
+            headers={"content-type": "application/json"},
+            body=SchemaParser.serialize_patch(body),
+        )
+        response = yield http_client.fetch(request, raise_error=False)
+
+        assert response.code == 200
+        updated = SchemaParser.parse_principal(
+            response.body.decode("utf-8"), from_string=True
+        )
+        assert len(updated.roles) == 0
+
+    @pytest.mark.gen_test
+    def test_patch_set_roles(self, http_client, base_url, mongo_principal, mongo_role):
+        mongo_role.save()
+        mongo_principal.save()
+        new_role = Role(
+            name="new_role", description="Some desc", roles=[], permissions=["bg-all"]
+        )
+        new_role.save()
+
+        body = PatchOperation(operation="set", path="/roles", value=["new_role"])
+
+        url = base_url + "/api/v1/users/" + str(mongo_principal.id)
+        request = HTTPRequest(
+            url,
+            method="PATCH",
+            headers={"content-type": "application/json"},
+            body=SchemaParser.serialize_patch(body),
+        )
+        response = yield http_client.fetch(request, raise_error=False)
+
+        assert response.code == 200
+        updated = SchemaParser.parse_principal(
+            response.body.decode("utf-8"), from_string=True
+        )
+        assert len(updated.roles) == 1
+        assert updated.roles[0].name == "new_role"
+
+    @pytest.mark.gen_test
+    def test_patch_invalid_role(
+        self, http_client, base_url, mongo_principal, mongo_role
+    ):
+        mongo_role.save()
+        mongo_principal.save()
+
+        body = PatchOperation(operation="add", path="/roles", value=["DOES_NOT_EXIST"])
+
+        url = base_url + "/api/v1/users/" + str(mongo_principal.id)
+        request = HTTPRequest(
+            url,
+            method="PATCH",
+            headers={"content-type": "application/json"},
+            body=SchemaParser.serialize_patch(body),
+        )
+        response = yield http_client.fetch(request, raise_error=False)
+
+        assert response.code == 400
+
+    @pytest.mark.gen_test
+    def test_patch_invalid_password_op(
+        self, http_client, base_url, mongo_principal, mongo_role
+    ):
+        mongo_role.save()
+        mongo_principal.save()
+
+        body = PatchOperation(
+            operation="INVALID", path="/password", value="new_password"
+        )
+
+        url = base_url + "/api/v1/users/" + str(mongo_principal.id)
+        request = HTTPRequest(
+            url,
+            method="PATCH",
+            headers={"content-type": "application/json"},
+            body=SchemaParser.serialize_patch(body),
+        )
+        response = yield http_client.fetch(request, raise_error=False)
+
+        assert response.code == 400
+
+    @pytest.mark.gen_test
+    def test_patch_password_update(
+        self, http_client, base_url, mongo_principal, mongo_role
+    ):
+        mongo_role.save()
+        mongo_principal.save()
+
+        body = PatchOperation(
+            operation="update", path="/password", value="new_password"
+        )
+        url = base_url + "/api/v1/users/" + str(mongo_principal.id)
+        request = HTTPRequest(
+            url,
+            method="PATCH",
+            headers={"content-type": "application/json"},
+            body=SchemaParser.serialize_patch(body),
+        )
+        response = yield http_client.fetch(request, raise_error=False)
+
+        assert response.code == 200
+
+    @pytest.mark.gen_test
+    def test_patch_password_update_meta(
+        self, http_client, base_url, mongo_principal, mongo_role
+    ):
+        mongo_role.save()
+        mongo_principal.metadata = {"auto_change": True, "changed": False}
+        mongo_principal.save()
+        body = PatchOperation(
+            operation="update", path="/password", value="new_password"
+        )
+
+        url = base_url + "/api/v1/users/" + str(mongo_principal.id)
+        request = HTTPRequest(
+            url,
+            method="PATCH",
+            headers={"content-type": "application/json"},
+            body=SchemaParser.serialize_patch(body),
+        )
+        response = yield http_client.fetch(request, raise_error=False)
+
+        assert response.code == 200
+        updated = SchemaParser.parse_principal(
+            response.body.decode("utf-8"), from_string=True
+        )
+        assert updated.metadata.get("changed") is True

--- a/test/unit/controllers/users_api_test.py
+++ b/test/unit/controllers/users_api_test.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+import json
+
+import pytest
+from tornado.httpclient import HTTPRequest
+
+from bg_utils.mongo.models import Principal, Role
+from brewtils.models import PatchOperation
+from brewtils.schema_parser import SchemaParser
+
+
+@pytest.fixture(autouse=True)
+def drop_principals(app):
+    Principal.drop_collection()
+    Role.drop_collection()
+
+
+class TestPrincipalAPI(object):
+    @pytest.mark.gen_test
+    def test_get(self, http_client, base_url, mongo_principal, mongo_role):
+        mongo_role.save()
+        mongo_principal.save()
+        url = base_url + "/api/v1/users/" + str(mongo_principal.id)
+        response = yield http_client.fetch(url)
+        assert 200 == response.code
+        response_principal = json.loads(response.body.decode('utf-8'))
+        assert response_principal['id'] == str(mongo_principal.id)
+
+    @pytest.mark.gen_test
+    @pytest.mark.parametrize(
+        "operation,value,expected_username,succeed",
+        [
+            ('update', 'new_username', 'new_username', True),
+            ('INVALID', None, None, False),
+        ],
+    )
+    def test_patch_users_username(
+            self,
+            http_client,
+            base_url,
+            mongo_principal,
+            mongo_role,
+            operation,
+            value,
+            expected_username,
+            succeed,
+    ):
+        mongo_role.save()
+        mongo_principal.save()
+
+        body = PatchOperation(
+            operation=operation,
+            path='/username',
+            value=value,
+        )
+
+        request = HTTPRequest(
+            base_url + "/api/v1/users/" + str(mongo_principal.id),
+            method="PATCH",
+            headers={"content-type": "application/json"},
+            body=SchemaParser.serialize_patch(body),
+            )
+        response = yield http_client.fetch(request, raise_error=False)
+
+        if succeed:
+            assert response.code == 200
+            updated = SchemaParser.parse_principal(
+                response.body.decode("utf-8"), from_string=True
+            )
+            assert updated.username == expected_username
+
+        else:
+            assert response.code >= 400
+


### PR DESCRIPTION
This set of PRs goes along with the following:

* [brewtils PR](https://github.com/beer-garden/brewtils/pull/122)
* [bg-utils PR](https://github.com/beer-garden/bg-utils/pull/44)

## Major Updates

* Cookie Authentication
  * To support a better UI, it is helpful to introduce the concept of session ids. We do this through secure cookies which tornado mostly has built in. A new way to be able to get a session ID is to request one, with `remember_me` in the body.
* Refresh Token API Deprecated
  * The way we are refreshing token requires people to put a secret in the URL. This is less than good, and has been deprecated in favor of the new `PATCH` on `/api/v1/tokens/`

## Minor Updates

* You can now modify a role's description
* New `guest_login_enabled` flag
* You can now modify a user's name/password

## Bug Fixes

* When hitting `/version` a 500 would occur if we couldn't connect to Bartender, now it simply reports that I can't get Bartender's version number.
* Sometimes `ObjectId` was being compared to `str` which always results in false, I think what we want is to `str` the ids