### PR TITLE
Auth tweak

### DIFF
--- a/brew_view/controllers/misc_controllers.py
+++ b/brew_view/controllers/misc_controllers.py
@@ -8,7 +8,6 @@ from brew_view.base_handler import BaseHandler
 
 
 class ConfigHandler(BaseHandler):
-
     def get(self):
         """Subset of configuration options that the frontend needs"""
         configs = {

--- a/brew_view/controllers/token_api.py
+++ b/brew_view/controllers/token_api.py
@@ -173,13 +173,9 @@ class TokenListAPI(BaseHandler):
                 if op.path == "/payload":
                     token = self._refresh_token(op.value)
                 else:
-                    error_msg = "Unsupported path '%s'" % op.path
-                    self.logger.warning(error_msg)
-                    raise ModelValidationError(error_msg)
+                    raise ModelValidationError("Unsupported path '%s'" % op.path)
             else:
-                error_msg = "Unsupported operation '%s'" % op.operation
-                self.logger.warning(error_msg)
-                raise ModelValidationError(error_msg)
+                raise ModelValidationError("Unsupported operation '%s'" % op.operation)
 
         self.write(json.dumps(token))
 

--- a/brew_view/specification.py
+++ b/brew_view/specification.py
@@ -190,8 +190,7 @@ SPECIFICATION = {
                 "type": "bool",
                 "default": True,
                 "description": "Only applicable if auth is enabled. If set to "
-                "true, guests can login without username/"
-                "passwords.",
+                "true, guests can login without username/passwords.",
             },
             "token": {
                 "type": "dict",


### PR DESCRIPTION
The only real change here is the checking for user update permission. I didn't verify this, but it looked like before this change anybody could have changed any user's username.

There's a slight cost to the change - in the case where a user with USER_UPDATE is updating permissions for another user it'll check for the permission twice. I don't think that's a very expensive check, but if it is we could add a `if user_id == str(self.current_user.id):` check.