### PR TITLE
Adding request id to timeout exceeded log message

### DIFF
--- a/brew_view/controllers/request_list_api.py
+++ b/brew_view/controllers/request_list_api.py
@@ -366,7 +366,9 @@ class RequestListAPI(BaseHandler):
 
                 request_model.reload()
             except TimeoutError:
-                raise TimeoutExceededError()
+                raise TimeoutExceededError(
+                    "Timeout exceeded for request %s" % request_id
+                )
             finally:
                 brew_view.request_map.pop(request_id, None)
 


### PR DESCRIPTION
This makes the log message for a `TimeoutExceededError` more useful.