### PR TITLE
Issue/180

### DIFF
--- a/brew_view/static/src/js/configs/dt_renderer.js
+++ b/brew_view/static/src/js/configs/dt_renderer.js
@@ -20,7 +20,7 @@ export default function runDTRenderer(DTRendererService) {
               .attr('id', 'childCheck')
               .attr('type', 'checkbox')
               .css('margin-top', '-4px')
-              .change(() => { $('#requestIndexTable').dataTable().fnUpdate(); })
+              .change(() => { $('.dataTable').dataTable().fnUpdate(); })
           )
           .append(
             $('<label>')
@@ -37,13 +37,30 @@ export default function runDTRenderer(DTRendererService) {
           .attr('type', 'button')
           .addClass('btn')
           .addClass('btn-default')
-          .addClass('fa')
-          .addClass('fa-refresh')
-          .css('margin-right', '20px')
+          .css('margin-left', '20px')
           .css('margin-bottom', '5px')
-          .text(' Refresh')
-          .click(() => { $('#requestIndexTable').dataTable().fnUpdate(); });
-        $('.dataTables_length').prepend(refreshButton);
+          .click(() => { $('.dataTable').dataTable().fnUpdate(); })
+          .append($('<span>')
+            .addClass('fa')
+            .addClass('fa-refresh')
+            .css('padding-right', '5px')
+          )
+          .append($('<span>').text('Refresh'));
+        $('.dataTables_length').append(refreshButton);
+      }
+
+      if (options.newData) {
+        let newData = $('<span>')
+          .attr('id', 'newData')
+          .css('margin-left', '20px')
+          .css('margin-bottom', '5px')
+          .append($('<span>')
+            .addClass('glyphicon')
+            .addClass('glyphicon-info-sign')
+            .css('padding-right', '5px')
+          )
+          .append($('<span>').text('Updated Info Detected'));
+        $('.dataTables_length').append(newData);
       }
 
       let spinner = $('<span>')

--- a/brew_view/static/src/js/configs/dt_renderer.js
+++ b/brew_view/static/src/js/configs/dt_renderer.js
@@ -37,6 +37,7 @@ export default function runDTRenderer(DTRendererService) {
           .attr('type', 'button')
           .addClass('btn')
           .addClass('btn-default')
+          .addClass('btn-sm')
           .css('margin-left', '20px')
           .css('margin-bottom', '5px')
           .click(() => { $('.dataTable').dataTable().fnUpdate(); })
@@ -59,7 +60,7 @@ export default function runDTRenderer(DTRendererService) {
             .addClass('glyphicon-info-sign')
             .css('padding-right', '5px')
           )
-          .append($('<span>').text('Updated Info Detected'));
+          .append($('<span>').text('Updates Detected'));
         $('.dataTables_length').append(newData);
       }
 

--- a/brew_view/static/src/js/controllers/request_index.js
+++ b/brew_view/static/src/js/controllers/request_index.js
@@ -6,6 +6,7 @@ requestIndexController.$inject = [
   'DTOptionsBuilder',
   'DTColumnBuilder',
   'RequestService',
+  'EventService',
 ];
 
 /**
@@ -14,13 +15,15 @@ requestIndexController.$inject = [
  * @param  {Object} DTOptionsBuilder  Data-tables' options builder object.
  * @param  {Object} DTColumnBuilder   Data-tables' column builder object.
  * @param  {Object} RequestService    Beer-Garden Request Service.
+ * @param  {Object} EventService      Beer-Garden Event Service.
  */
 export default function requestIndexController(
     $scope,
     $compile,
     DTOptionsBuilder,
     DTColumnBuilder,
-    RequestService) {
+    RequestService,
+    EventService) {
   $scope.setWindowTitle('requests');
 
   $scope.requests = {};
@@ -159,6 +162,20 @@ export default function requestIndexController(
   $scope.instanceCreated = function(_instance) {
     $scope.dtInstance = _instance;
   };
+
+  EventService.setCallback((message) => {
+    let event = JSON.parse(message.data);
+
+    switch (event.name) {
+      case 'REQUEST_CREATED':
+      case 'REQUEST_STARTED':
+      case 'REQUEST_COMPLETED':
+        if ($scope.dtInstance) {
+          $scope.dtInstance.reloadData(() => {}, false);
+        }
+        break;
+    }
+  });
 
   $scope.$on('userChange', function() {
     $scope.response = undefined;

--- a/brew_view/static/src/js/controllers/request_index.js
+++ b/brew_view/static/src/js/controllers/request_index.js
@@ -50,6 +50,9 @@ export default function requestIndexController(
             recordsFiltered: response.headers('recordsFiltered'),
             recordsTotal: response.headers('recordsTotal'),
           });
+
+          // Hide the 'new data' notification
+          $('#newData').css('visibility', 'hidden');
         },
         (response) => {
           $scope.response = response;
@@ -100,6 +103,7 @@ export default function requestIndexController(
     .withOption('serverSide', true)
     .withOption('refreshButton', true)
     .withOption('childContainer', true)
+    .withOption('newData', true)
     .withPaginationType('full_numbers')
     .withBootstrap()
     .withOption('createdRow', function(row, data, dataIndex) {
@@ -171,7 +175,7 @@ export default function requestIndexController(
       case 'REQUEST_STARTED':
       case 'REQUEST_COMPLETED':
         if ($scope.dtInstance) {
-          $scope.dtInstance.reloadData(() => {}, false);
+          $('#newData').css('visibility', 'visible');
         }
         break;
     }


### PR DESCRIPTION
So I think this *could* be useful, but I'm interested in other opinions.

We now how a `Refresh` button on the request index page. Super. But there's no way to know ahead of time if pushing it will accomplish anything. There could be no change in the data since the last time you loaded it.

This PR adds a little notification next to the refresh button whenever any Request-related event is detected. This gives a small visual indication that new data is available, so clicking `Refresh` might be worth it.

I didn't want to auto-reload whenever changes are detected because that could be really annoying. You could be about to click on a request when they all shift down because new request just happened. Worst-case you might not even know you didn't click on the the request you think you did. Also, this is how the systems management page operates now and it's pretty annoying.

My concern here is that the notification doesn't mean that the table will definitely change if you click refresh. For example, if you're filtering on `ERROR` requests and a new request gets created you'll see the notification. However, clicking the `Refresh` button won't result in a visible change because no new `ERROR` request was created.

So I'm not sure if this helps or hurts - let me know what you think.

This fixes beer-garden/beer-garden#180