### PR TITLE
About page Grafana links now use application name config option

### DIFF
--- a/brew_view/static/src/partials/about.html
+++ b/brew_view/static/src/partials/about.html
@@ -14,10 +14,10 @@
               <a href="{{config.metricsUrl}}">Metrics</a> - Link to the configured metrics backend.
             </li>
             <li>
-              <a href="https://grafana.com/dashboards/6621">Grafana Dashboard (Beer Garden)</a> - A grafana dashboard for monitoring Beer Garden Performance.
+              <a href="https://grafana.com/dashboards/6621">Grafana Dashboard ({{config.applicationName}})</a> - A grafana dashboard for monitoring {{config.applicationName}} performance.
             </li>
             <li>
-              <a href="https://grafana.com/dashboards/6624">Grafana Dashboard (Plugins)</a> - A grafana dashboard for monitoring Beer Garden plugin performance.
+              <a href="https://grafana.com/dashboards/6624">Grafana Dashboard (Plugins)</a> - A grafana dashboard for monitoring {{config.applicationName}} plugin performance.
             </li>
           </ul>
         </div>


### PR DESCRIPTION
This fixes beer-garden/beer-garden#301