### PR TITLE
Ternary operator needs parenthesis here

### DIFF
--- a/brew_view/static/src/js/services/event_service.js
+++ b/brew_view/static/src/js/services/event_service.js
@@ -21,7 +21,7 @@ export default function eventService($websocket, TokenService) {
     },
     connect: () => {
       if (window.WebSocket && !socketConnection) {
-        let eventUrl = window.location.protocol === 'https:' ? 'wss://' : 'ws://' +
+        let eventUrl = (window.location.protocol === 'https:' ? 'wss://' : 'ws://') +
           window.location.host +
           window.location.pathname +
           'api/v1/socket/events';


### PR DESCRIPTION
The corrects an issue where https websockets failed to connect.