### PR TITLE
Urlencoding semicolons in request index search fields

### DIFF
--- a/brew_view/static/src/js/controllers/request_index.js
+++ b/brew_view/static/src/js/controllers/request_index.js
@@ -40,6 +40,13 @@ export default function requestIndexController(
         data.columns.push({'data': 'parent'});
       }
 
+      // Not urlencoding semicolons in the search values breaks the backend
+      for (let column of data.columns) {
+        if (column.search && column.search.value) {
+          column.search.value = column.search.value.replace(/;/g, '%3B');
+        }
+      }
+
       RequestService.getRequests(data).then(
         (response) => {
           $scope.response = response;


### PR DESCRIPTION
This is a stopgap for beer-garden/beer-garden#302.

For some reason the Tornado query parameter parsing is breaking if there's a raw semicolon inside of a search string.

This PR urlencodes semicolons before the request is made which prevents the error. I'm going to leave the issue open though, since it's still possible to issue a request another way (using the OpenAPI page, for example) that will break.

The 'correct' fix here is to fix the parsing on the backend. I'm worried that will require messing with Tornado parsing though, since the query parameters are already incorrect when we pull them off the Request in the handler.

It probably also doesn't help that our request API is datatables query parameters (#77)