### PR TITLE
Rendering HTML request output

### DIFF
--- a/brew_view/static/src/js/controllers/request_view.js
+++ b/brew_view/static/src/js/controllers/request_view.js
@@ -38,7 +38,8 @@ export default function requestViewController(
   $scope.childrenCollapsed = true;
 
   $scope.rawOutput = undefined;
-  $scope.formattedOutput = '';
+  $scope.htmlOutput = '';
+  $scope.jsonOutput = '';
   $scope.formattedParameters = '';
   $scope.formattedAvailable = false;
   $scope.formatErrorTitle = undefined;
@@ -75,7 +76,8 @@ export default function requestViewController(
   };
 
   $scope.formatOutput = function() {
-    $scope.formattedOutput = '';
+    $scope.htmlOutput = '';
+    $scope.jsonOutput = '';
     $scope.formattedAvailable = false;
     $scope.showFormatted = false;
     $scope.formatErrorTitle = undefined;
@@ -86,13 +88,17 @@ export default function requestViewController(
     try {
       if (rawOutput === undefined || rawOutput == null) {
         rawOutput = 'null';
+      } else if ($scope.data.output_type == 'HTML') {
+        $scope.htmlOutput = rawOutput;
+        $scope.formattedAvailable = true;
+        $scope.showFormatted = true;
       } else if ($scope.data.output_type == 'JSON') {
         try {
           let parsedOutput = JSON.parse($scope.data.output);
           rawOutput = $scope.stringify(parsedOutput);
 
           if ($scope.countNodes($scope.formattedOutput) < 1000) {
-            $scope.formattedOutput = rawOutput;
+            $scope.jsonOutput = rawOutput;
             $scope.formattedAvailable = true;
             $scope.showFormatted = true;
           } else {
@@ -177,7 +183,8 @@ export default function requestViewController(
     $scope.data = response.data;
 
     $scope.rawOutput = undefined;
-    $scope.formattedOutput = undefined;
+    $scope.htmlOutput = undefined;
+    $scope.jsonOutput = undefined;
     $scope.formattedAvailable = false;
     $scope.showFormatted = false;
     $scope.formatErrorTitle = undefined;

--- a/brew_view/static/src/partials/request_view.html
+++ b/brew_view/static/src/partials/request_view.html
@@ -104,8 +104,11 @@
             <i class="fa fa-spinner fa-pulse fa-3x"></i>
           </div>
           <pre id="rawOutput" ng-show="!showFormatted && service.isComplete(data)">{{rawOutput}}</pre>
-          <div id="formattedOutput" ng-show="showFormatted && service.isComplete(data)">
-            <div ui-ace="{ onLoad: loadPreview }" ng-model="formattedOutput"
+          <div id="htmlOutput" ng-show="showFormatted && service.isComplete(data) && htmlOutput">
+            <div ng-bind-html="htmlOutput"></div>
+          </div>
+          <div id="jsonOutput" ng-show="showFormatted && service.isComplete(data) && jsonOutput">
+            <div ui-ace="{ onLoad: loadPreview }" ng-model="jsonOutput"
               ng-if="formattedAvailable && format_error === undefined" style="width: 100%;"></div>
           </div>
         </div>


### PR DESCRIPTION
This fixes beer-garden/beer-garden#312. Angular sanitizes by default when using `ng-bind-html`, so there's nothing we need to do there.