### PR TITLE
Adding max-height rule to css for typeahead dropdowns

### DIFF
--- a/brew_view/static/package.json
+++ b/brew_view/static/package.json
@@ -4,7 +4,7 @@
   "description": "Front End to a Command and Control Framework",
   "main": "app.py",
   "dependencies": {
-    "@beer-garden/addons": "^0.5.0",
+    "@beer-garden/addons": "^0.6.0",
     "@beer-garden/builder": "^0.0.4",
     "@uirouter/angularjs": "^1.0.3",
     "ace-builds": "^1.2.8",

--- a/brew_view/static/src/styles/custom.css
+++ b/brew_view/static/src/styles/custom.css
@@ -216,6 +216,10 @@ table.dataTable{
     max-height: 195px;
     overflow: auto;
 }
+[uib-typeahead-popup].dropdown-menu{
+    max-height: 195px;
+    overflow: auto;
+}
 
 .red-border{
     border: 2px solid red;


### PR DESCRIPTION
This fixes beer-garden/beer-garden#318.