### PR TITLE
User / Role permissions update through UI

### DIFF
--- a/brew_view/static/src/js/controllers/admin_role.js
+++ b/brew_view/static/src/js/controllers/admin_role.js
@@ -211,7 +211,7 @@ export function adminRoleController(
     let original = _.find($scope.serverRoles, {'id': changed.id});
 
     // Since this is a result of a click, we need to update primary permissions
-    changed.primaryPermissions[permission] = changed.permission[permission];
+    changed.primaryPermissions[permission] = changed.permissions[permission];
 
     if (changed.permissions[permission] != original.permissions[permission]){
         changed.permissionsChanged = true;

--- a/brew_view/static/src/js/controllers/admin_role.js
+++ b/brew_view/static/src/js/controllers/admin_role.js
@@ -157,7 +157,7 @@ export function adminRoleController(
     let original = _.find($scope.serverRoles, {'id': changed.id});
 
     // Since this is a result of a click, we need to update primary roles
-    changed.primaryRoles[roleName] = changed.roles[roleName];
+    changed.primaryRoles[roleName] = !changed.roles[roleName];
 
     // Ok, so if a role is changing that means that the 'primary' permissions
     // have not changed. So recalculate the coalesced permissions (the
@@ -206,16 +206,14 @@ export function adminRoleController(
     }
   };
 
-  $scope.permissionChange = function(roleId) {
-    let original = _.find($scope.serverRoles, {'id': roleId});
-    let changed = _.find($scope.roles, {'id': roleId});
+  $scope.permissionChange = function(permission) {
+    let changed = $scope.selectedRole;
+    let original = _.find($scope.serverRoles, {'id': changed.id});
 
-    changed.permissionsChanged = false;
-    for (let key in changed.permissions) {
-      if (changed.permissions[key] != original.permissions[key]) {
-       changed.permissionsChanged = true;
-      }
-    }
+    // Since this is a result of a click, we need to update primary permissions
+    changed.primaryPermissions[permission] = !changed.permission[permission];
+
+    changed.permissionsChanged = true;
   };
 
   /**

--- a/brew_view/static/src/js/controllers/admin_role.js
+++ b/brew_view/static/src/js/controllers/admin_role.js
@@ -157,7 +157,7 @@ export function adminRoleController(
     let original = _.find($scope.serverRoles, {'id': changed.id});
 
     // Since this is a result of a click, we need to update primary roles
-    changed.primaryRoles[roleName] = !changed.roles[roleName];
+    changed.primaryRoles[roleName] = changed.roles[roleName];
 
     // Ok, so if a role is changing that means that the 'primary' permissions
     // have not changed. So recalculate the coalesced permissions (the
@@ -211,9 +211,11 @@ export function adminRoleController(
     let original = _.find($scope.serverRoles, {'id': changed.id});
 
     // Since this is a result of a click, we need to update primary permissions
-    changed.primaryPermissions[permission] = !changed.permission[permission];
+    changed.primaryPermissions[permission] = changed.permission[permission];
 
-    changed.permissionsChanged = true;
+    if (changed.permissions[permission] != original.permissions[permission]){
+        changed.permissionsChanged = true;
+    }
   };
 
   /**

--- a/brew_view/static/src/js/controllers/admin_user.js
+++ b/brew_view/static/src/js/controllers/admin_user.js
@@ -136,7 +136,7 @@ export function adminUserController(
     let changed = $scope.selectedUser;
 
     // Since this is a result of a click, we need to update primary roles
-    changed.primaryRoles[roleName] = !changed.roles[roleName];
+    changed.primaryRoles[roleName] = changed.roles[roleName];
 
     // Then get the list of roles that are checked
     let primaryRoleNames = mapToArray(changed.primaryRoles);

--- a/brew_view/static/src/js/controllers/admin_user.js
+++ b/brew_view/static/src/js/controllers/admin_user.js
@@ -136,7 +136,7 @@ export function adminUserController(
     let changed = $scope.selectedUser;
 
     // Since this is a result of a click, we need to update primary roles
-    changed.primaryRoles[roleName] = changed.roles[roleName];
+    changed.primaryRoles[roleName] = !changed.roles[roleName];
 
     // Then get the list of roles that are checked
     let primaryRoleNames = mapToArray(changed.primaryRoles);

--- a/brew_view/static/src/partials/admin_role.html
+++ b/brew_view/static/src/partials/admin_role.html
@@ -34,7 +34,7 @@
         <div ng-repeat="roleName in roleNames">
           <input type="checkbox" id="{{roleName}}"
             ng-model="selectedRole.roles[roleName]"
-            ng-click="roleChange(roleName)"
+            ng-change="roleChange(roleName)"
             ng-disabled="isRoleDisabled(roleName)" />
           <label for="{{roleName}}"
             ng-style="color(selectedRole.id, 'roles.'+roleName)"
@@ -46,7 +46,7 @@
           <span ng-repeat="permission in permGroup" class="col-sm-3">
             <input type="checkbox" id="{{permission}}"
               ng-model="selectedRole.permissions[permission]"
-              ng-click="permissionChange(permission)"
+              ng-change="permissionChange(permission)"
               ng-disabled="isPermissionDisabled(permission)" />
             <label for="{{permission}}"
               ng-style="color(selectedRole.id, 'permissions.'+permission)"

--- a/brew_view/static/src/partials/admin_role.html
+++ b/brew_view/static/src/partials/admin_role.html
@@ -46,7 +46,7 @@
           <span ng-repeat="permission in permGroup" class="col-sm-3">
             <input type="checkbox" id="{{permission}}"
               ng-model="selectedRole.permissions[permission]"
-              ng-click="permissionChange(selectedRole.id)"
+              ng-click="permissionChange(permission)"
               ng-disabled="isPermissionDisabled(permission)" />
             <label for="{{permission}}"
               ng-style="color(selectedRole.id, 'permissions.'+permission)"

--- a/brew_view/static/src/partials/admin_user.html
+++ b/brew_view/static/src/partials/admin_user.html
@@ -34,7 +34,7 @@
         <div ng-repeat="role in raws.roles">
           <input type="checkbox" id="{{role.name}}"
             ng-model="selectedUser.roles[role.name]"
-            ng-click="roleChange(role.name)"
+            ng-change="roleChange(role.name)"
             ng-disabled="isRoleDisabled(role.name)" />
           <label for="{{role.name}}"
             ng-style="color(selectedUser.id, 'roles.'+role.name)"


### PR DESCRIPTION
fixes beer-garden/beer-garden#345

When an admin selected a role or nested role to assign the user/role was not changing the field to the inverse value. These changes make that update.

Updated the Permissions interface for Roles to have interact with the selected user in the same format as Nested Roles