### PR TITLE
Fixing bug where scheduler would not work with self-signed cert

### DIFF
--- a/brew_view/__init__.py
+++ b/brew_view/__init__.py
@@ -222,9 +222,9 @@ def _setup_application():
         port=config.web.port,
         url_prefix=config.web.url_prefix,
         ssl_enabled=config.web.ssl.enabled,
-        ca_cert=config.web.ssl.ca_cert,
         username=config.scheduler.auth.username,
         password=config.scheduler.auth.password,
+        ca_verify=False,
     )
 
     thrift_context = _setup_thrift_context()


### PR DESCRIPTION
This fixes beer-garden/beer-garden#391.

Currently the scheduler has to use an easy client to create requests. If brew-view is running in TLS mode with a self-signed cert we need to be able to set `ca_verify=False` for that easy client.

Instead of adding a config option for that (since there's no "scheduler" section already) this PR just always sets `ca_verify=False`.